### PR TITLE
[PATCH v2] linux-dpdk: initial experimental eventdev support

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.4"
+config_file_version = "0.1.5"
 
 # Pool options
 pool: {
@@ -97,6 +97,21 @@ sched_basic: {
 		worker  = 1
 		control = 1
 	}
+}
+
+sched_eventdev: {
+	# Eventdev supports up to RTE_EVENT_MAX_QUEUES_PER_DEV queues and these
+	# have to be mapped to ODP's scheduled queue types at startup. If the
+	# combined number of queues is zero, eventdev queues are divined evenly
+	# amongst the ODP queue types.
+	num_atomic_queues = 0
+	num_ordered_queues = 0
+	num_parallel_queues = 0
+
+	# Number of event ports (zero = all available). Each ODP worker
+	# calling scheduler or doing queue enqueue requires a private event
+	# port.
+	num_ports = 0
 }
 
 timer: {

--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -8,6 +8,9 @@ AC_MSG_NOTICE([Looking for DPDK PMDs at $1])
 for filename in "$1"/librte_pmd_*.a; do
 cur_driver=`basename "$filename" .a | sed -e 's/^lib//'`
 
+# Skip rte_pmd_ring to avoid multiple definition errors
+AS_IF([test "x$cur_driver" = "xrte_pmd_ring"], [continue])
+
 # Match pattern is filled to 'filename' once if no matches are found
 AS_IF([test "x$cur_driver" = "xrte_pmd_*"], [break])
 

--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -173,7 +173,6 @@ __LIB__libodp_linux_la_SOURCES = \
 			   ../linux-generic/pktio/dpdk_parse.c \
 			   odp_packet_flags.c \
 			   ../linux-generic/odp_packet_io.c \
-			   ../linux-generic/pktio/loop.c \
 			   ../linux-generic/pktio/null.c \
 			   ../linux-generic/odp_pkt_queue.c \
 			   odp_pool.c \

--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -93,6 +93,7 @@ noinst_HEADERS = \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_datamodel.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_inlines.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_classification_internal.h \
+		  include/odp_eventdev_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_forward_typedefs_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_global_data.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_init_internal.h \
@@ -177,12 +178,14 @@ __LIB__libodp_linux_la_SOURCES = \
 			   ../linux-generic/odp_pkt_queue.c \
 			   odp_pool.c \
 			   odp_queue_basic.c \
+			   odp_queue_eventdev.c \
 			   odp_queue_if.c \
 			   ../linux-generic/odp_queue_lf.c \
 			   odp_queue_spsc.c \
 			   ../linux-generic/odp_rwlock.c \
 			   ../linux-generic/odp_rwlock_recursive.c \
 			   ../linux-generic/odp_schedule_basic.c \
+			   odp_schedule_eventdev.c \
 			   odp_schedule_if.c \
 			   ../linux-generic/odp_schedule_sp.c \
 			   odp_shared_memory.c \

--- a/platform/linux-dpdk/README
+++ b/platform/linux-dpdk/README
@@ -1,4 +1,5 @@
 Copyright (c) 2018-2019, Linaro Limited
+Copyright (c) 2019, Nokia
 All rights reserved.
 
 SPDX-License-Identifier:        BSD-3-Clause
@@ -56,6 +57,9 @@ Enable pcap pmd to use ODP-DPDK without DPDK supported NIC's:
 
 Enable openssl crypto pmd to use openssl with odp-dpdk:
     sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config
+
+Optionally, add more queues to eventdev:
+    sed -ri 's,(CONFIG_RTE_EVENT_MAX_QUEUES_PER_DEV=).*,\1255,' .config
 
 Now return to parent directory and build DPDK:
     cd ..
@@ -288,3 +292,27 @@ Before running the application, export ODP_PLATFORM_PARAMS with corresponding
 crypto vdev's.
 ex: ODP_PLATFORM_PARAMS="--vdev cryptodev_aesni_mb_pmd,max_nb_sessions=32 \
     --vdev cryptodev_null_pmd,max_nb_sessions=32"
+
+9. Using eventdev scheduling and queues (experimental)
+======================================================
+
+ODP-DPDK includes experimental implementations of ODP scheduler, queues, and
+scheduled pktio using DPDK event device library. The initial implementation
+has been validated using only the standard software eventdev poll mode driver
+with DPDK v18.11. Due to some pending eventdev bugs the implementation is not
+yet tested in the ODP CI.
+
+To use eventdev one must set ODP_SCHEDULER environment variable to "eventdev"
+and provide the necessary platform parameters to DPDK.
+
+Refer to DPDK event device driver documentation for platform defails:
+https://doc.dpdk.org/guides/eventdevs/index.html
+
+In case of the standard software eventdev implementation one must enable a DPDK
+service core, which will perform scheduling and receive packets for the
+scheduled pktio input queues. The DPDK service cores and the ODP application
+cores should not overlap.
+
+Exaple how to run odp_scheduling test application using eventdev:
+    sudo ODP_SCHEDULER="eventdev" ODP_PLATFORM_PARAMS="--vdev event_sw0 -s 0x4" \
+    ./odp_scheduling -c 1

--- a/platform/linux-dpdk/include/odp_eventdev_internal.h
+++ b/platform/linux-dpdk/include/odp_eventdev_internal.h
@@ -1,0 +1,191 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP eventdev - implementation internal
+ */
+
+#ifndef ODP_EVENTDEV_H_
+#define ODP_EVENTDEV_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/align.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/plat/strong_types.h>
+#include <odp/api/queue.h>
+#include <odp/api/schedule_types.h>
+#include <odp/api/ticketlock.h>
+#include <odp_align_internal.h>
+#include <odp_config_internal.h>
+#include <odp_forward_typedefs_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_ptr_ring_mpmc_internal.h>
+#include <odp_queue_if.h>
+#include <odp_schedule_if.h>
+
+#include <rte_config.h>
+#include <rte_eventdev.h>
+
+#include <stdint.h>
+
+#define RX_ADAPTER_INIT           0
+#define RX_ADAPTER_STOPPED        1
+#define RX_ADAPTER_RUNNING        2
+
+/* Maximum schedule burst size */
+#define MAX_SCHED_BURST 128
+ODP_STATIC_ASSERT(MAX_SCHED_BURST <= UINT16_MAX,
+		  "too large schedule burst");
+
+/* Number of scheduling groups */
+#define NUM_SCHED_GRPS 32
+
+ODP_STATIC_ASSERT(sizeof(((struct rte_event *)0)->queue_id) == sizeof(uint8_t),
+		  "eventdev queue ID size changed");
+
+ODP_STATIC_ASSERT(ODP_CONFIG_QUEUES >= RTE_EVENT_MAX_QUEUES_PER_DEV,
+		  "unable to map all eventdev queues");
+
+struct queue_entry_s {
+	/* The first cache line is read only */
+	queue_enq_fn_t       ODP_ALIGNED_CACHE enqueue;
+	queue_deq_fn_t       dequeue;
+	queue_enq_multi_fn_t enqueue_multi;
+	queue_deq_multi_fn_t dequeue_multi;
+	uint32_t          index;
+	odp_queue_type_t  type;
+
+	ring_mpmc_t       ring_mpmc;
+
+	odp_ticketlock_t  lock;
+
+	odp_atomic_u64_t  num_timers;
+	int               status;
+	odp_schedule_sync_t sync;
+
+	queue_deq_multi_fn_t orig_dequeue_multi;
+	odp_queue_param_t param;
+	odp_pktin_queue_t pktin;
+	odp_pktout_queue_t pktout;
+	char              name[ODP_QUEUE_NAME_LEN];
+};
+
+union queue_entry_u {
+	struct queue_entry_s s;
+	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
+};
+
+/* Eventdev global data */
+typedef struct {
+	queue_entry_t   queue[ODP_CONFIG_QUEUES];
+	odp_shm_t       shm;
+	struct rte_event_dev_config config;
+	struct {
+		odp_ticketlock_t lock;
+		int  status;
+		uint8_t id;
+		uint8_t single_queue;
+	} rx_adapter;
+	odp_atomic_u32_t num_started;
+	uint8_t     dev_id;
+	uint8_t     num_event_ports;
+	uint8_t     num_prio;
+
+	struct {
+		uint8_t num_atomic;
+		uint8_t num_ordered;
+		uint8_t num_parallel;
+	} event_queue;
+	pktio_entry_t *pktio[RTE_MAX_ETHPORTS];
+
+	odp_ticketlock_t port_lock;
+	struct {
+		uint8_t linked;
+	} port[ODP_THREAD_COUNT_MAX];
+
+	struct {
+		uint32_t max_queue_size;
+		uint32_t default_queue_size;
+	} plain_config;
+
+	struct {
+		uint32_t max_queue_size;
+	} sched_config;
+
+	/* Schedule groups */
+	odp_thrmask_t    mask_all;
+	struct {
+		char           name[ODP_SCHED_GROUP_NAME_LEN];
+		odp_thrmask_t  mask;
+		uint8_t	       allocated;
+		queue_entry_t *queue[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	} grp[NUM_SCHED_GRPS];
+	odp_ticketlock_t grp_lock;
+
+	/* Scheduler interface config options (not used in fast path) */
+	schedule_config_t config_if;
+
+} eventdev_global_t;
+
+/* Eventdev local data */
+typedef struct {
+	struct {
+		struct rte_event event[MAX_SCHED_BURST];
+		uint16_t idx;
+		uint16_t count;
+	} cache;
+	uint8_t port_id;
+	uint8_t paused;
+	uint8_t started;
+} eventdev_local_t;
+
+extern eventdev_global_t *eventdev_gbl;
+extern __thread eventdev_local_t eventdev_local;
+
+int service_setup(uint32_t service_id);
+
+int dummy_link_queues(uint8_t dev_id, uint8_t dummy_linked_queues[], int num);
+
+int dummy_unlink_queues(uint8_t dev_id, uint8_t dummy_linked_queues[], int num);
+
+void rx_adapter_port_stop(uint16_t port_id);
+
+int rx_adapter_close(void);
+
+static inline uint8_t event_schedule_type(odp_schedule_sync_t sync)
+{
+	/* Ordered queues implemented using atomic queues */
+	if (sync == ODP_SCHED_SYNC_PARALLEL)
+		return RTE_SCHED_TYPE_PARALLEL;
+	else
+		return RTE_SCHED_TYPE_ATOMIC;
+}
+
+static inline odp_queue_t queue_from_qentry(queue_entry_t *queue)
+{
+	return (odp_queue_t)queue;
+}
+
+static inline queue_entry_t *qentry_from_index(uint32_t queue_id)
+{
+	return &eventdev_gbl->queue[queue_id];
+}
+
+static inline queue_entry_t *qentry_from_handle(odp_queue_t handle)
+{
+	return (queue_entry_t *)(uintptr_t)handle;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/include/odp_packet_io_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_io_internal.h
@@ -185,6 +185,8 @@ static inline void pktio_cls_enabled_set(pktio_entry_t *entry, int ena)
 	entry->s.cls_enabled = ena;
 }
 
+uint16_t dpdk_pktio_port_id(pktio_entry_t *entry);
+
 int input_pkts(pktio_entry_t *pktio_entry, odp_packet_t pkt_table[], int num);
 
 extern const pktio_if_ops_t loopback_pktio_ops;

--- a/platform/linux-dpdk/include/odp_packet_io_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_io_internal.h
@@ -185,6 +185,8 @@ static inline void pktio_cls_enabled_set(pktio_entry_t *entry, int ena)
 	entry->s.cls_enabled = ena;
 }
 
+int input_pkts(pktio_entry_t *pktio_entry, odp_packet_t pkt_table[], int num);
+
 extern const pktio_if_ops_t loopback_pktio_ops;
 extern const pktio_if_ops_t null_pktio_ops;
 extern const pktio_if_ops_t dpdk_pktio_ops;

--- a/platform/linux-dpdk/include/odp_packet_io_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_io_internal.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -40,7 +41,7 @@ extern "C" {
 /* Forward declaration */
 struct pktio_if_ops;
 
-#define PKTIO_PRIVATE_SIZE 1280
+#define PKTIO_PRIVATE_SIZE 1728
 
 struct pktio_entry {
 	const struct pktio_if_ops *ops; /**< Implementation specific methods */
@@ -189,7 +190,6 @@ uint16_t dpdk_pktio_port_id(pktio_entry_t *entry);
 
 int input_pkts(pktio_entry_t *pktio_entry, odp_packet_t pkt_table[], int num);
 
-extern const pktio_if_ops_t loopback_pktio_ops;
 extern const pktio_if_ops_t null_pktio_ops;
 extern const pktio_if_ops_t dpdk_pktio_ops;
 extern const pktio_if_ops_t * const pktio_if_ops[];

--- a/platform/linux-dpdk/m4/configure.m4
+++ b/platform/linux-dpdk/m4/configure.m4
@@ -43,6 +43,9 @@ case "${host}" in
   ;;
 esac
 
+# Required for experimental rte_event_port_unlinks_in_progress() API
+DPDK_CFLAGS="${DPDK_CFLAGS} -DALLOW_EXPERIMENTAL_API"
+
 ODP_CHECK_CFLAG([-Wno-error=cast-align])
 AC_DEFINE([ODP_PKTIO_DPDK], [1])
 AC_CONFIG_COMMANDS_PRE([dnl

--- a/platform/linux-dpdk/odp_queue_eventdev.c
+++ b/platform/linux-dpdk/odp_queue_eventdev.c
@@ -1,0 +1,1288 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp_eventdev_internal.h>
+#include <odp/api/hints.h>
+#include <odp/api/queue.h>
+#include <odp/api/schedule.h>
+#include <odp/api/shared_memory.h>
+#include <odp/api/sync.h>
+#include <odp/api/plat/queue_inline_types.h>
+#include <odp/api/plat/ticketlock_inlines.h>
+#include <odp_config_internal.h>
+#include <odp_buffer_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_libconfig_internal.h>
+#include <odp_queue_if.h>
+#include <odp_schedule_if.h>
+#include <odp_timer_internal.h>
+
+#include <rte_config.h>
+#include <rte_eventdev.h>
+#include <rte_service.h>
+
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+
+#define LOCK(queue_ptr)      odp_ticketlock_lock(&((queue_ptr)->s.lock))
+#define UNLOCK(queue_ptr)    odp_ticketlock_unlock(&((queue_ptr)->s.lock))
+#define LOCK_INIT(queue_ptr) odp_ticketlock_init(&((queue_ptr)->s.lock))
+
+#define MIN_QUEUE_SIZE 8
+#define DEFAULT_QUEUE_SIZE (4 * 1024)
+#define MAX_QUEUE_SIZE (8 * 1024)
+
+#define EVENT_QUEUE_FLOWS 32
+
+#define QUEUE_STATUS_FREE         0
+#define QUEUE_STATUS_READY        1
+#define QUEUE_STATUS_SCHED        2
+
+/* Number of priority levels  */
+#define NUM_PRIO 8
+
+/* Thread local eventdev context */
+__thread eventdev_local_t eventdev_local;
+
+/* Global eventdev context */
+eventdev_global_t *eventdev_gbl;
+
+extern _odp_queue_inline_offset_t _odp_queue_inline_offset;
+
+static inline uint32_t queue_to_index(odp_queue_t handle)
+{
+	queue_entry_t *qentry = (queue_entry_t *)(uintptr_t)handle;
+
+	return qentry->s.index;
+}
+
+static int queue_init(queue_entry_t *queue, const char *name,
+		      const odp_queue_param_t *param);
+
+static uint8_t event_queue_ids(odp_schedule_sync_t sync, uint8_t *first_id)
+{
+	*first_id = 0;
+	if (sync == ODP_SCHED_SYNC_ATOMIC)
+		return eventdev_gbl->event_queue.num_atomic;
+
+	*first_id += eventdev_gbl->event_queue.num_atomic;
+	if (sync == ODP_SCHED_SYNC_PARALLEL)
+		return eventdev_gbl->event_queue.num_parallel;
+
+	*first_id += eventdev_gbl->event_queue.num_parallel;
+	if (sync == ODP_SCHED_SYNC_ORDERED)
+		return eventdev_gbl->event_queue.num_ordered;
+
+	ODP_ABORT("Invalid schedule sync type\n");
+	return 0;
+}
+
+static int read_config_file(eventdev_global_t *eventdev)
+{
+	const char *str;
+	int val = 0;
+
+	ODP_PRINT("\nScheduler config\n----------------\n");
+
+	str = "sched_eventdev.num_atomic_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n", str, val);
+	eventdev->event_queue.num_atomic = val;
+
+	str = "sched_eventdev.num_ordered_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n", str, val);
+	eventdev->event_queue.num_ordered = val;
+
+	str = "sched_eventdev.num_parallel_queues";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n\n", str, val);
+	eventdev->event_queue.num_parallel = val;
+
+	str = "sched_eventdev.num_ports";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	ODP_PRINT("%s: %i\n\n", str, val);
+	eventdev->num_event_ports = val;
+
+	return 0;
+}
+
+static int queue_capa(odp_queue_capability_t *capa, int sched ODP_UNUSED)
+{
+	memset(capa, 0, sizeof(odp_queue_capability_t));
+
+	/* Reserve some queues for internal use */
+	capa->max_queues        = ODP_CONFIG_QUEUES;
+	capa->plain.max_num     = ODP_CONFIG_QUEUES -
+					RTE_EVENT_MAX_QUEUES_PER_DEV;
+	capa->plain.max_size    = eventdev_gbl->plain_config.max_queue_size - 1;
+	capa->plain.lockfree.max_num  = 0;
+	capa->plain.lockfree.max_size = 0;
+
+#if ODP_DEPRECATED_API
+	uint16_t max_sched;
+
+	max_sched = RTE_MAX(RTE_MAX(eventdev_gbl->event_queue.num_atomic,
+				    eventdev_gbl->event_queue.num_ordered),
+			    eventdev_gbl->event_queue.num_parallel);
+	capa->sched.max_num     = RTE_MIN(ODP_CONFIG_QUEUES, max_sched);
+	capa->sched.max_size    = eventdev_gbl->config.nb_events_limit;
+
+	if (sched) {
+		capa->max_ordered_locks = sched_fn->max_ordered_locks();
+		capa->max_sched_groups  = sched_fn->num_grps();
+		capa->sched_prios       = odp_schedule_num_prio();
+	}
+#endif
+
+	return 0;
+}
+
+static void print_dev_info(const struct rte_event_dev_info *info)
+{
+	ODP_PRINT("\nEvent device info\n"
+		  "-----------------\n"
+		  "driver name: %s\n"
+		  "min_dequeue_timeout_ns: %" PRIu32 "\n"
+		  "max_dequeue_timeout_ns: %" PRIu32 "\n"
+		  "dequeue_timeout_ns: %" PRIu32 "\n"
+		  "max_event_queues: %" PRIu8 "\n"
+		  "max_event_queue_flows: %" PRIu32 "\n"
+		  "max_event_queue_priority_levels: %" PRIu8 "\n"
+		  "max_event_priority_levels: %" PRIu8 "\n"
+		  "max_event_ports: %" PRIu8 "\n"
+		  "max_event_port_dequeue_depth: %" PRIu8 "\n"
+		  "max_event_port_enqueue_depth: %" PRIu32 "\n"
+		  "max_num_events: %" PRId32 "\n"
+		  "event_dev_cap: %" PRIu32 "\n",
+		  info->driver_name,
+		  info->min_dequeue_timeout_ns,
+		  info->max_dequeue_timeout_ns,
+		  info->dequeue_timeout_ns,
+		  info->max_event_queues,
+		  info->max_event_queue_flows,
+		  info->max_event_queue_priority_levels,
+		  info->max_event_priority_levels,
+		  info->max_event_ports,
+		  info->max_event_port_dequeue_depth,
+		  info->max_event_port_enqueue_depth,
+		  info->max_num_events,
+		  info->event_dev_cap);
+}
+
+int service_setup(uint32_t service_id)
+{
+	uint32_t cores[RTE_MAX_LCORE];
+	uint32_t lcore = 0;
+	int32_t num_cores;
+	int32_t num_serv;
+	int32_t min_num_serv = INT32_MAX;
+
+	if (!rte_service_lcore_count()) {
+		ODP_ERR("No service cores available\n");
+		return -1;
+	}
+
+	/* Use the service core with the smallest number of running services */
+	num_cores = rte_service_lcore_list(cores, RTE_MAX_LCORE);
+	while (num_cores--) {
+		rte_service_map_lcore_set(service_id, cores[num_cores], 0);
+		num_serv = rte_service_lcore_count_services(cores[num_cores]);
+		if (num_serv < min_num_serv) {
+			lcore = cores[num_cores];
+			min_num_serv = num_serv;
+		}
+	}
+	if (rte_service_map_lcore_set(service_id, lcore, 1)) {
+		ODP_ERR("Unable to map service to core\n");
+		return -1;
+	}
+	return 0;
+}
+
+static int alloc_queues(eventdev_global_t *eventdev,
+			const struct rte_event_dev_info *info)
+{
+	int num_queues;
+
+	if (!eventdev->event_queue.num_atomic &&
+	    !eventdev->event_queue.num_ordered &&
+	    !eventdev->event_queue.num_parallel) {
+		uint8_t queue_per_type = info->max_event_queues / 3;
+
+		/* Divide eventdev queues evenly to ODP queue types */
+		eventdev->event_queue.num_atomic = queue_per_type;
+		eventdev->event_queue.num_ordered = queue_per_type;
+		eventdev->event_queue.num_parallel = queue_per_type;
+
+		num_queues = 3 * queue_per_type;
+	} else {
+		num_queues = eventdev->event_queue.num_atomic +
+			     eventdev->event_queue.num_ordered +
+			     eventdev->event_queue.num_parallel;
+	}
+
+	return num_queues;
+}
+
+static int setup_queues(uint8_t dev_id, uint8_t first_queue_id,
+			uint8_t num_queues, uint32_t num_flows,
+			odp_schedule_sync_t sync)
+{
+	uint8_t i, j;
+
+	for (i = first_queue_id, j = 0; j < num_queues; i++, j++) {
+		struct rte_event_queue_conf queue_conf;
+		queue_entry_t *queue = qentry_from_index(i);
+
+		queue->s.sync = sync;
+
+		if (rte_event_queue_default_conf_get(dev_id, i, &queue_conf)) {
+			ODP_ERR("rte_event_queue_default_conf_get failed\n");
+			return -1;
+		}
+		queue_conf.schedule_type = event_schedule_type(sync);
+
+		/* Ordered queues implemented using atomic queues */
+		if (sync == ODP_SCHED_SYNC_ATOMIC ||
+		    sync == ODP_SCHED_SYNC_ORDERED)
+			queue_conf.nb_atomic_flows = num_flows;
+
+		if (rte_event_queue_setup(dev_id, i, &queue_conf)) {
+			ODP_ERR("rte_event_queue_setup failed\n");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int configure_queues(uint8_t dev_id, uint32_t num_flows)
+{
+	uint8_t first_queue_id;
+	uint8_t num_queues;
+
+	num_queues = event_queue_ids(ODP_SCHED_SYNC_ATOMIC, &first_queue_id);
+	if (setup_queues(dev_id, first_queue_id, num_queues, num_flows,
+			 ODP_SCHED_SYNC_ATOMIC))
+		return -1;
+
+	num_queues = event_queue_ids(ODP_SCHED_SYNC_PARALLEL, &first_queue_id);
+	if (setup_queues(dev_id, first_queue_id, num_queues, num_flows,
+			 ODP_SCHED_SYNC_PARALLEL))
+		return -1;
+
+	num_queues = event_queue_ids(ODP_SCHED_SYNC_ORDERED, &first_queue_id);
+	if (setup_queues(dev_id, first_queue_id, num_queues, num_flows,
+			 ODP_SCHED_SYNC_ORDERED))
+		return -1;
+
+	return 0;
+}
+
+static int queue_is_linked(uint8_t dev_id, uint8_t queue_id)
+{
+	uint8_t i;
+
+	for (i = 0; i < eventdev_gbl->config.nb_event_ports; i++) {
+		uint8_t queues[RTE_EVENT_MAX_QUEUES_PER_DEV];
+		uint8_t priorities[RTE_EVENT_MAX_QUEUES_PER_DEV];
+		int num_links;
+		int j;
+
+		num_links = rte_event_port_links_get(dev_id, i, queues,
+						     priorities);
+		for (j = 0; j < num_links; j++) {
+			if (queues[j] == queue_id)
+				return 1;
+		}
+	}
+	return 0;
+}
+
+/* Dummy link all unlinked queues to port zero to pass evendev start */
+int dummy_link_queues(uint8_t dev_id, uint8_t dummy_linked_queues[], int num)
+{
+	uint8_t priority = RTE_EVENT_DEV_PRIORITY_NORMAL;
+	uint8_t queue_id;
+	int ret;
+	int num_linked = 0;
+
+	for (queue_id = 0; queue_id < num; queue_id++) {
+		if (queue_is_linked(dev_id, queue_id))
+			continue;
+
+		ret = rte_event_port_link(dev_id, 0, &queue_id, &priority, 1);
+		if (ret != 1) {
+			ODP_ERR("rte_event_port_link failed: %d\n", ret);
+			return -1;
+		}
+		dummy_linked_queues[num_linked++] = queue_id;
+	}
+	return num_linked;
+}
+
+/* Remove dummy links to port zero */
+int dummy_unlink_queues(uint8_t dev_id, uint8_t dummy_linked_queues[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++) {
+		if (rte_event_port_unlink(dev_id, 0, &dummy_linked_queues[i],
+					  1) < 0) {
+			ODP_ERR("rte_event_port_unlink failed\n");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int configure_ports(uint8_t dev_id,
+			   const struct rte_event_dev_config *dev_conf)
+{
+	struct rte_event_port_conf port_conf;
+	uint8_t i;
+
+	for (i = 0; i < dev_conf->nb_event_ports; i++) {
+		if (rte_event_port_default_conf_get(dev_id, i, &port_conf)) {
+			ODP_ERR("rte_event_port_default_conf_get failed\n");
+			return -1;
+		}
+
+		port_conf.new_event_threshold = dev_conf->nb_events_limit;
+		port_conf.dequeue_depth = dev_conf->nb_event_port_dequeue_depth;
+		port_conf.enqueue_depth = dev_conf->nb_event_port_enqueue_depth;
+
+		if (rte_event_port_setup(dev_id, i, &port_conf)) {
+			ODP_ERR("rte_event_port_setup failed\n");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static int init_event_dev(void)
+{
+	uint32_t num_flows;
+	uint8_t dev_id = 0;
+	uint8_t rx_adapter_id = 0;
+	uint8_t dummy_links[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	struct rte_event_dev_info info;
+	struct rte_event_dev_config config;
+	int num_dummy_links;
+	int ret;
+	int i;
+
+	if (rte_event_dev_count() < 1) {
+		ODP_ERR("No eventdev devices found\n");
+		return -1;
+	}
+
+	if (read_config_file(eventdev_gbl))
+		return -1;
+
+	eventdev_gbl->dev_id = dev_id;
+	eventdev_gbl->rx_adapter.id = rx_adapter_id;
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_INIT;
+	odp_ticketlock_init(&eventdev_gbl->rx_adapter.lock);
+	odp_atomic_init_u32(&eventdev_gbl->num_started, 0);
+
+	odp_ticketlock_init(&eventdev_gbl->port_lock);
+	for (i = 0; i < ODP_THREAD_COUNT_MAX; i++)
+		eventdev_gbl->port[i].linked = 0;
+
+	if (rte_event_dev_info_get(dev_id, &info)) {
+		ODP_ERR("rte_event_dev_info_get failed\n");
+		return -1;
+	}
+	print_dev_info(&info);
+
+	eventdev_gbl->num_prio = RTE_MIN(NUM_PRIO,
+					 info.max_event_queue_priority_levels);
+	if (!(info.event_dev_cap & RTE_EVENT_DEV_CAP_QUEUE_QOS)) {
+		ODP_PRINT("  Only one QoS level supported!\n");
+		eventdev_gbl->num_prio = 1;
+	}
+
+	memset(&config, 0, sizeof(struct rte_event_dev_config));
+	config.dequeue_timeout_ns = 0;
+	config.nb_events_limit  = info.max_num_events;
+	config.nb_event_queues = alloc_queues(eventdev_gbl, &info);
+
+	config.nb_event_ports = RTE_MIN(ODP_THREAD_COUNT_MAX,
+					(int)info.max_event_ports);
+	/* RX adapter requires additional port which is reserved when
+	 * rte_event_eth_rx_adapter_queue_add() is called. */
+	config.nb_event_ports -= 1;
+	if (eventdev_gbl->num_event_ports &&
+	    eventdev_gbl->num_event_ports < config.nb_event_ports)
+		config.nb_event_ports = eventdev_gbl->num_event_ports;
+
+	num_flows = (EVENT_QUEUE_FLOWS < info.max_event_queue_flows) ?
+			EVENT_QUEUE_FLOWS : info.max_event_queue_flows;
+	config.nb_event_queue_flows = num_flows;
+	config.nb_event_port_dequeue_depth = (MAX_SCHED_BURST <
+			info.max_event_port_dequeue_depth) ? MAX_SCHED_BURST :
+					info.max_event_port_dequeue_depth;
+	config.nb_event_port_enqueue_depth = (MAX_SCHED_BURST <
+			info.max_event_port_enqueue_depth) ? MAX_SCHED_BURST :
+					info.max_event_port_enqueue_depth;
+	/* RTE_EVENT_DEV_CFG_PER_DEQUEUE_TIMEOUT not supported by the SW
+	 * eventdev */
+	config.event_dev_cfg = 0;
+
+	ret = rte_event_dev_configure(dev_id, &config);
+	if (ret < 0) {
+		ODP_ERR("rte_event_dev_configure failed\n");
+		return -1;
+	}
+	eventdev_gbl->config = config;
+	eventdev_gbl->num_event_ports = config.nb_event_ports;
+
+	if (configure_ports(dev_id, &config)) {
+		ODP_ERR("Configuring eventdev ports failed\n");
+		return -1;
+	}
+
+	if (configure_queues(dev_id, num_flows)) {
+		ODP_ERR("Configuring eventdev queues failed\n");
+		return -1;
+	}
+
+	/* Eventdev requires that each queue is linked to at least one
+	 * port at startup. */
+	num_dummy_links = dummy_link_queues(dev_id, dummy_links,
+					    config.nb_event_queues);
+
+	if (!(info.event_dev_cap & RTE_EVENT_DEV_CAP_DISTRIBUTED_SCHED)) {
+		uint32_t service_id;
+
+		ret = rte_event_dev_service_id_get(dev_id, &service_id);
+		if (ret) {
+			ODP_ERR("Unable to retrieve service ID\n");
+			return -1;
+		}
+		if (service_setup(service_id)) {
+			ODP_ERR("Failed to setup service core\n");
+			return -1;
+		}
+	}
+
+	if (rte_event_dev_start(dev_id)) {
+		ODP_ERR("rte_event_dev_start failed\n");
+		return -1;
+	}
+
+	/* Unlink all ports from queues. Thread specific ports will be linked
+	 * when the application calls schedule/enqueue for the first time. */
+	if (dummy_unlink_queues(dev_id, dummy_links, num_dummy_links)) {
+		rte_event_dev_stop(dev_id);
+		rte_event_dev_close(dev_id);
+		return -1;
+	}
+
+	/* Scheduling groups */
+	odp_ticketlock_init(&eventdev_gbl->grp_lock);
+
+	for (i = 0; i < NUM_SCHED_GRPS; i++) {
+		memset(eventdev_gbl->grp[i].name, 0,
+		       ODP_SCHED_GROUP_NAME_LEN);
+		odp_thrmask_zero(&eventdev_gbl->grp[i].mask);
+	}
+
+	eventdev_gbl->grp[ODP_SCHED_GROUP_ALL].allocated = 1;
+	eventdev_gbl->grp[ODP_SCHED_GROUP_WORKER].allocated = 1;
+	eventdev_gbl->grp[ODP_SCHED_GROUP_CONTROL].allocated = 1;
+
+	odp_thrmask_setall(&eventdev_gbl->mask_all);
+
+	return 0;
+}
+
+static int queue_init_global(void)
+{
+	uint32_t max_queue_size;
+	uint32_t i;
+	odp_shm_t shm;
+	odp_queue_capability_t capa;
+
+	ODP_DBG("Queue init global\n");
+
+	/* Fill in queue entry field offsets for inline functions */
+	memset(&_odp_queue_inline_offset, 0,
+	       sizeof(_odp_queue_inline_offset_t));
+	_odp_queue_inline_offset.context = offsetof(queue_entry_t,
+						    s.param.context);
+
+	shm = odp_shm_reserve("_odp_eventdev_gbl",
+			      sizeof(eventdev_global_t),
+			      ODP_CACHE_LINE_SIZE, 0);
+
+	eventdev_gbl = odp_shm_addr(shm);
+
+	if (eventdev_gbl == NULL)
+		return -1;
+
+	memset(eventdev_gbl, 0, sizeof(eventdev_global_t));
+	eventdev_gbl->shm = shm;
+
+	if (init_event_dev())
+		return -1;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		/* init locks */
+		queue_entry_t *queue = qentry_from_index(i);
+
+		LOCK_INIT(queue);
+		queue->s.index  = i;
+	}
+
+	max_queue_size = eventdev_gbl->config.nb_events_limit;
+	eventdev_gbl->plain_config.default_queue_size = DEFAULT_QUEUE_SIZE;
+	eventdev_gbl->plain_config.max_queue_size = MAX_QUEUE_SIZE;
+	eventdev_gbl->sched_config.max_queue_size = max_queue_size;
+
+	queue_capa(&capa, 0);
+
+	ODP_DBG("  queue_entry_t size %u\n", sizeof(queue_entry_t));
+	ODP_DBG("  max num queues     %u\n", capa.max_queues);
+	ODP_DBG("  max plain queue size     %u\n", capa.plain.max_size);
+	ODP_DBG("  max num lockfree   %u\n", capa.plain.lockfree.max_num);
+	ODP_DBG("  max lockfree size  %u\n\n", capa.plain.lockfree.max_size);
+
+	return 0;
+}
+
+static int queue_init_local(void)
+{
+	int thread_id = odp_thread_id();
+
+	memset(&eventdev_local, 0, sizeof(eventdev_local_t));
+
+	ODP_ASSERT(thread_id <= UINT8_MAX);
+	eventdev_local.port_id = thread_id;
+	eventdev_local.paused = 0;
+	eventdev_local.started = 0;
+
+	return 0;
+}
+
+static int queue_term_local(void)
+{
+	return 0;
+}
+
+static int queue_term_global(void)
+{
+	int ret = 0;
+	queue_entry_t *queue;
+	int i;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		queue = qentry_from_index(i);
+		LOCK(queue);
+		if (queue->s.status != QUEUE_STATUS_FREE) {
+			ODP_ERR("Not destroyed queue: %s\n", queue->s.name);
+			ret = -1;
+		}
+		UNLOCK(queue);
+	}
+
+	if (rx_adapter_close())
+		ret = -1;
+
+	rte_event_dev_stop(eventdev_gbl->dev_id);
+
+	/* Fix for DPDK 17.11 sync bug */
+	sleep(1);
+
+	if (rte_event_dev_close(eventdev_gbl->dev_id)) {
+		ODP_ERR("Failed to close event device\n");
+		ret = -1;
+	}
+
+	if (odp_shm_free(eventdev_gbl->shm)) {
+		ODP_ERR("Shm free failed for evendev\n");
+		ret = -1;
+	}
+
+	return ret;
+}
+
+static int queue_capability(odp_queue_capability_t *capa)
+{
+	return queue_capa(capa, 1);
+}
+
+static odp_queue_type_t queue_type(odp_queue_t handle)
+{
+	return qentry_from_handle(handle)->s.type;
+}
+
+static odp_schedule_sync_t queue_sched_type(odp_queue_t handle)
+{
+	return qentry_from_handle(handle)->s.param.sched.sync;
+}
+
+static odp_schedule_prio_t queue_sched_prio(odp_queue_t handle)
+{
+	return qentry_from_handle(handle)->s.param.sched.prio;
+}
+
+static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
+{
+	return qentry_from_handle(handle)->s.param.sched.group;
+}
+
+static uint32_t queue_lock_count(odp_queue_t handle)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
+		queue->s.param.sched.lock_count : 0;
+}
+
+static odp_queue_t queue_create(const char *name,
+				const odp_queue_param_t *param)
+{
+	uint32_t i;
+	queue_entry_t *queue;
+	odp_queue_type_t type;
+	odp_queue_param_t default_param;
+	odp_queue_t handle = ODP_QUEUE_INVALID;
+
+	if (param == NULL) {
+		odp_queue_param_init(&default_param);
+		param = &default_param;
+	}
+
+	type = param->type;
+
+	if (type == ODP_QUEUE_TYPE_SCHED) {
+		if (param->sched.prio < odp_schedule_min_prio() ||
+		    param->sched.prio > odp_schedule_max_prio()) {
+			ODP_ERR("Bad queue priority: %i\n", param->sched.prio);
+			return ODP_QUEUE_INVALID;
+		}
+		if (param->size > eventdev_gbl->sched_config.max_queue_size)
+			return ODP_QUEUE_INVALID;
+	} else {
+		if (param->size > eventdev_gbl->plain_config.max_queue_size)
+			return ODP_QUEUE_INVALID;
+	}
+
+	/* Only blocking queues supported */
+	if (param->nonblocking != ODP_BLOCKING)
+		return ODP_QUEUE_INVALID;
+
+	/* First RTE_EVENT_MAX_QUEUES_PER_DEV IDs are mapped directly
+	 * to eventdev queue IDs */
+	i = (type == ODP_QUEUE_TYPE_SCHED) ? 0 : RTE_EVENT_MAX_QUEUES_PER_DEV;
+
+	for (; i < ODP_CONFIG_QUEUES; i++) {
+		queue = qentry_from_index(i);
+
+		if (queue->s.status != QUEUE_STATUS_FREE)
+			continue;
+
+		if (type == ODP_QUEUE_TYPE_SCHED) {
+			if (i >= RTE_EVENT_MAX_QUEUES_PER_DEV) {
+				ODP_ERR("No free eventdev queues\n");
+				return ODP_QUEUE_INVALID;
+			}
+			if (queue->s.sync != param->sched.sync)
+				continue;
+		}
+
+		LOCK(queue);
+		if (queue->s.status == QUEUE_STATUS_FREE) {
+			if (queue_init(queue, name, param)) {
+				UNLOCK(queue);
+				ODP_ERR("Queue init failed\n");
+				return ODP_QUEUE_INVALID;
+			}
+
+			if (type == ODP_QUEUE_TYPE_SCHED)
+				queue->s.status = QUEUE_STATUS_SCHED;
+			else
+				queue->s.status = QUEUE_STATUS_READY;
+			handle = queue_from_qentry(queue);
+			UNLOCK(queue);
+			break;
+		}
+		UNLOCK(queue);
+	}
+
+	if (handle == ODP_QUEUE_INVALID)
+		return ODP_QUEUE_INVALID;
+
+	if (type == ODP_QUEUE_TYPE_SCHED) {
+		if (sched_fn->init_queue(queue->s.index,
+					 &queue->s.param.sched)) {
+			queue->s.status = QUEUE_STATUS_FREE;
+			ODP_ERR("schedule queue init failed\n");
+			return ODP_QUEUE_INVALID;
+		}
+	}
+
+	return handle;
+}
+
+static int queue_destroy(odp_queue_t handle)
+{
+	queue_entry_t *queue;
+
+	queue = qentry_from_handle(handle);
+
+	if (handle == ODP_QUEUE_INVALID)
+		return -1;
+
+	LOCK(queue);
+	if (queue->s.status == QUEUE_STATUS_FREE) {
+		UNLOCK(queue);
+		ODP_ERR("queue \"%s\" already free\n", queue->s.name);
+		return -1;
+	}
+	if (queue->s.type == ODP_QUEUE_TYPE_PLAIN) {
+		if (ring_mpmc_is_empty(queue->s.ring_mpmc) == 0) {
+			UNLOCK(queue);
+			ODP_ERR("queue \"%s\" not empty\n", queue->s.name);
+			return -1;
+		}
+		ring_mpmc_free(queue->s.ring_mpmc);
+	}
+
+	switch (queue->s.status) {
+	case QUEUE_STATUS_READY:
+		queue->s.status = QUEUE_STATUS_FREE;
+		break;
+	case QUEUE_STATUS_SCHED:
+		queue->s.status = QUEUE_STATUS_FREE;
+		sched_fn->destroy_queue(queue->s.index);
+		break;
+	default:
+		ODP_ABORT("Unexpected queue status\n");
+	}
+
+	UNLOCK(queue);
+
+	return 0;
+}
+
+static int queue_context_set(odp_queue_t handle, void *context,
+			     uint32_t len ODP_UNUSED)
+{
+	odp_mb_full();
+	qentry_from_handle(handle)->s.param.context = context;
+	odp_mb_full();
+	return 0;
+}
+
+static odp_queue_t queue_lookup(const char *name)
+{
+	uint32_t i;
+
+	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
+		queue_entry_t *queue = qentry_from_index(i);
+
+		if (queue->s.status == QUEUE_STATUS_FREE)
+			continue;
+
+		LOCK(queue);
+		if (strcmp(name, queue->s.name) == 0) {
+			/* found it */
+			UNLOCK(queue);
+			return queue_from_qentry(queue);
+		}
+		UNLOCK(queue);
+	}
+
+	return ODP_QUEUE_INVALID;
+}
+
+static inline int _plain_queue_enq_multi(odp_queue_t handle,
+					 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	queue_entry_t *queue;
+	int num_enq;
+	ring_mpmc_t ring_mpmc;
+
+	queue = qentry_from_handle(handle);
+	ring_mpmc = queue->s.ring_mpmc;
+
+	num_enq = ring_mpmc_enq_multi(ring_mpmc, (void **)buf_hdr, num);
+
+	return num_enq;
+}
+
+static inline int _plain_queue_deq_multi(odp_queue_t handle,
+					 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	int num_deq;
+	queue_entry_t *queue;
+	ring_mpmc_t ring_mpmc;
+
+	queue = qentry_from_handle(handle);
+	ring_mpmc = queue->s.ring_mpmc;
+
+	num_deq = ring_mpmc_deq_multi(ring_mpmc, (void **)buf_hdr, num);
+
+	return num_deq;
+}
+
+static int plain_queue_enq_multi(odp_queue_t handle,
+				 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	return _plain_queue_enq_multi(handle, buf_hdr, num);
+}
+
+static int plain_queue_enq(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
+{
+	int ret;
+
+	ret = _plain_queue_enq_multi(handle, &buf_hdr, 1);
+
+	if (ret == 1)
+		return 0;
+	else
+		return -1;
+}
+
+static int plain_queue_deq_multi(odp_queue_t handle,
+				 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	return _plain_queue_deq_multi(handle, buf_hdr, num);
+}
+
+static odp_buffer_hdr_t *plain_queue_deq(odp_queue_t handle)
+{
+	odp_buffer_hdr_t *buf_hdr = NULL;
+	int ret;
+
+	ret = _plain_queue_deq_multi(handle, &buf_hdr, 1);
+
+	if (ret == 1)
+		return buf_hdr;
+	else
+		return NULL;
+}
+
+static int error_enqueue(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
+{
+	(void)buf_hdr;
+
+	ODP_ERR("Enqueue not supported (0x%" PRIx64 ")\n",
+		odp_queue_to_u64(handle));
+
+	return -1;
+}
+
+static int error_enqueue_multi(odp_queue_t handle,
+			       odp_buffer_hdr_t *buf_hdr[], int num)
+
+{
+	(void)buf_hdr;
+	(void)num;
+
+	ODP_ERR("Enqueue multi not supported (0x%" PRIx64 ")\n",
+		odp_queue_to_u64(handle));
+
+	return -1;
+}
+
+static odp_buffer_hdr_t *error_dequeue(odp_queue_t handle)
+{
+	ODP_ERR("Dequeue not supported (0x%" PRIx64 ")\n",
+		odp_queue_to_u64(handle));
+
+	return NULL;
+}
+
+static int error_dequeue_multi(odp_queue_t handle,
+			       odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	(void)buf_hdr;
+	(void)num;
+
+	ODP_ERR("Dequeue multi not supported (0x%" PRIx64 ")\n",
+		odp_queue_to_u64(handle));
+
+	return -1;
+}
+
+static void queue_param_init(odp_queue_param_t *params)
+{
+	memset(params, 0, sizeof(odp_queue_param_t));
+	params->type = ODP_QUEUE_TYPE_PLAIN;
+	params->enq_mode = ODP_QUEUE_OP_MT;
+	params->deq_mode = ODP_QUEUE_OP_MT;
+	params->nonblocking = ODP_BLOCKING;
+	params->sched.prio  = odp_schedule_default_prio();
+	params->sched.sync  = ODP_SCHED_SYNC_PARALLEL;
+	params->sched.group = ODP_SCHED_GROUP_ALL;
+}
+
+static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
+{
+	uint32_t queue_id;
+	queue_entry_t *queue;
+	int status;
+
+	if (odp_unlikely(info == NULL)) {
+		ODP_ERR("Unable to store info, NULL ptr given\n");
+		return -1;
+	}
+
+	queue_id = queue_to_index(handle);
+
+	if (odp_unlikely(queue_id >= ODP_CONFIG_QUEUES)) {
+		ODP_ERR("Invalid queue handle: 0x%" PRIx64 "\n",
+			odp_queue_to_u64(handle));
+		return -1;
+	}
+
+	queue = qentry_from_index(queue_id);
+
+	LOCK(queue);
+	status = queue->s.status;
+
+	if (odp_unlikely(status == QUEUE_STATUS_FREE)) {
+		UNLOCK(queue);
+		ODP_ERR("Invalid queue status:%d\n", status);
+		return -1;
+	}
+
+	info->name = queue->s.name;
+	info->param = queue->s.param;
+
+	UNLOCK(queue);
+
+	return 0;
+}
+
+static inline int _sched_queue_enq_multi(odp_queue_t handle,
+					 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	queue_entry_t *queue;
+	struct rte_event ev[CONFIG_BURST_SIZE];
+	uint16_t num_enq = 0;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t port_id = eventdev_local.port_id;
+	uint8_t sched;
+	uint8_t queue_id;
+	uint8_t priority;
+	int i;
+
+	queue = qentry_from_handle(handle);
+
+	LOCK(queue);
+
+	if (odp_unlikely(queue->s.status != QUEUE_STATUS_SCHED)) {
+		UNLOCK(queue);
+		ODP_ERR("Bad queue status\n");
+		return -1;
+	}
+
+	sched = event_schedule_type(queue->s.param.sched.sync);
+	queue_id = queue->s.index;
+	priority = queue->s.param.sched.prio;
+
+	UNLOCK(queue);
+
+	if (odp_unlikely(port_id >= eventdev_gbl->num_event_ports)) {
+		ODP_ERR("Max %" PRIu8 " scheduled workers supported\n",
+			eventdev_gbl->num_event_ports);
+		return 0;
+	}
+
+	for (i = 0; i < num; i++) {
+		ev[i].flow_id = 0;
+		ev[i].op = RTE_EVENT_OP_NEW;
+		ev[i].sched_type = sched;
+		ev[i].queue_id = queue_id;
+		ev[i].event_type = RTE_EVENT_TYPE_CPU;
+		ev[i].sub_event_type = 0;
+		ev[i].priority = priority;
+		ev[i].mbuf = &buf_hdr[i]->mb;
+	}
+
+	num_enq = rte_event_enqueue_new_burst(dev_id, port_id, ev, num);
+
+	return num_enq;
+}
+
+static int sched_queue_enq_multi(odp_queue_t handle,
+				 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	return _sched_queue_enq_multi(handle, buf_hdr, num);
+}
+
+static int sched_queue_enq(odp_queue_t handle, odp_buffer_hdr_t *buf_hdr)
+{
+	int ret;
+
+	ret = _sched_queue_enq_multi(handle, &buf_hdr, 1);
+
+	if (ret == 1)
+		return 0;
+	else
+		return -1;
+}
+
+static int queue_init(queue_entry_t *queue, const char *name,
+		      const odp_queue_param_t *param)
+{
+	uint32_t queue_size;
+	odp_queue_type_t queue_type;
+
+	queue_type = param->type;
+
+	if (name == NULL) {
+		queue->s.name[0] = 0;
+	} else {
+		strncpy(queue->s.name, name, ODP_QUEUE_NAME_LEN - 1);
+		queue->s.name[ODP_QUEUE_NAME_LEN - 1] = 0;
+	}
+	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
+	if (queue->s.param.sched.lock_count > sched_fn->max_ordered_locks())
+		return -1;
+
+	if (queue_type == ODP_QUEUE_TYPE_SCHED)
+		queue->s.param.deq_mode = ODP_QUEUE_OP_DISABLED;
+
+	queue->s.type = queue_type;
+	odp_atomic_init_u64(&queue->s.num_timers, 0);
+
+	queue->s.pktin = PKTIN_INVALID;
+	queue->s.pktout = PKTOUT_INVALID;
+
+	queue_size = param->size;
+	if (queue_size == 0)
+		queue_size = eventdev_gbl->plain_config.default_queue_size;
+
+	if (queue_size < MIN_QUEUE_SIZE)
+		queue_size = MIN_QUEUE_SIZE;
+
+	if (queue_type == ODP_QUEUE_TYPE_PLAIN &&
+	    queue_size > eventdev_gbl->plain_config.max_queue_size) {
+		ODP_ERR("Too large queue size %u\n", queue_size);
+		return -1;
+	}
+
+	/* Ring size must larger than queue_size */
+	if (CHECK_IS_POWER2(queue_size))
+		queue_size++;
+
+	/* Round up if not already a power of two */
+	queue_size = ROUNDUP_POWER2_U32(queue_size);
+
+	/* Default to error functions */
+	queue->s.enqueue            = error_enqueue;
+	queue->s.enqueue_multi      = error_enqueue_multi;
+	queue->s.dequeue            = error_dequeue;
+	queue->s.dequeue_multi      = error_dequeue_multi;
+	queue->s.orig_dequeue_multi = error_dequeue_multi;
+
+	if (queue_type == ODP_QUEUE_TYPE_PLAIN) {
+		queue->s.enqueue            = plain_queue_enq;
+		queue->s.enqueue_multi      = plain_queue_enq_multi;
+		queue->s.dequeue            = plain_queue_deq;
+		queue->s.dequeue_multi      = plain_queue_deq_multi;
+		queue->s.orig_dequeue_multi = plain_queue_deq_multi;
+
+		queue->s.ring_mpmc = ring_mpmc_create(queue->s.name,
+						      queue_size);
+		if (queue->s.ring_mpmc == NULL) {
+			ODP_ERR("Creating MPMC ring failed\n");
+			return -1;
+		}
+	} else {
+		queue->s.enqueue            = sched_queue_enq;
+		queue->s.enqueue_multi      = sched_queue_enq_multi;
+	}
+	return 0;
+}
+
+static uint64_t queue_to_u64(odp_queue_t hdl)
+{
+	return _odp_pri(hdl);
+}
+
+static odp_pktout_queue_t queue_get_pktout(odp_queue_t handle)
+{
+	queue_entry_t *qentry = qentry_from_handle(handle);
+
+	return qentry->s.pktout;
+}
+
+static void queue_set_pktout(odp_queue_t handle, odp_pktio_t pktio, int index)
+{
+	queue_entry_t *qentry = qentry_from_handle(handle);
+
+	qentry->s.pktout.pktio = pktio;
+	qentry->s.pktout.index = index;
+}
+
+static odp_pktin_queue_t queue_get_pktin(odp_queue_t handle)
+{
+	queue_entry_t *qentry = qentry_from_handle(handle);
+
+	return qentry->s.pktin;
+}
+
+static void queue_set_pktin(odp_queue_t handle, odp_pktio_t pktio, int index)
+{
+	queue_entry_t *qentry = qentry_from_handle(handle);
+
+	qentry->s.pktin.pktio = pktio;
+	qentry->s.pktin.index = index;
+}
+
+static void queue_set_enq_deq_func(odp_queue_t handle,
+				   queue_enq_fn_t enq,
+				   queue_enq_multi_fn_t enq_multi,
+				   queue_deq_fn_t deq,
+				   queue_deq_multi_fn_t deq_multi)
+{
+	queue_entry_t *qentry = qentry_from_handle(handle);
+
+	if (enq)
+		qentry->s.enqueue = enq;
+
+	if (enq_multi)
+		qentry->s.enqueue_multi = enq_multi;
+
+	if (deq)
+		qentry->s.dequeue = deq;
+
+	if (deq_multi)
+		qentry->s.dequeue_multi = deq_multi;
+}
+
+static int queue_orig_multi(odp_queue_t handle,
+			    odp_buffer_hdr_t **buf_hdr, int num)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	return queue->s.orig_dequeue_multi(handle, buf_hdr, num);
+}
+
+static int queue_api_enq_multi(odp_queue_t handle,
+			       const odp_event_t ev[], int num)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	if (odp_unlikely(num == 0))
+		return 0;
+
+	if (num > QUEUE_MULTI_MAX)
+		num = QUEUE_MULTI_MAX;
+
+	return queue->s.enqueue_multi(handle,
+				      (odp_buffer_hdr_t **)(uintptr_t)ev, num);
+}
+
+static void queue_timer_add(odp_queue_t handle)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	odp_atomic_inc_u64(&queue->s.num_timers);
+}
+
+static void queue_timer_rem(odp_queue_t handle)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	odp_atomic_dec_u64(&queue->s.num_timers);
+}
+
+static int queue_api_enq(odp_queue_t handle, odp_event_t ev)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+
+	return queue->s.enqueue(handle,
+				(odp_buffer_hdr_t *)(uintptr_t)ev);
+}
+
+static int queue_api_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+	int ret;
+
+	if (num > QUEUE_MULTI_MAX)
+		num = QUEUE_MULTI_MAX;
+
+	ret = queue->s.dequeue_multi(handle, (odp_buffer_hdr_t **)ev, num);
+
+	if (odp_global_rw->inline_timers &&
+	    odp_atomic_load_u64(&queue->s.num_timers))
+		timer_run(ret ? 2 : 1);
+
+	return ret;
+}
+
+static odp_event_t queue_api_deq(odp_queue_t handle)
+{
+	queue_entry_t *queue = qentry_from_handle(handle);
+	odp_event_t ev = (odp_event_t)queue->s.dequeue(handle);
+
+	if (odp_global_rw->inline_timers &&
+	    odp_atomic_load_u64(&queue->s.num_timers))
+		timer_run(ev != ODP_EVENT_INVALID ? 2 : 1);
+
+	return ev;
+}
+
+/* API functions */
+_odp_queue_api_fn_t queue_eventdev_api = {
+	.queue_create = queue_create,
+	.queue_destroy = queue_destroy,
+	.queue_lookup = queue_lookup,
+	.queue_capability = queue_capability,
+	.queue_context_set = queue_context_set,
+	.queue_enq = queue_api_enq,
+	.queue_enq_multi = queue_api_enq_multi,
+	.queue_deq = queue_api_deq,
+	.queue_deq_multi = queue_api_deq_multi,
+	.queue_type = queue_type,
+	.queue_sched_type = queue_sched_type,
+	.queue_sched_prio = queue_sched_prio,
+	.queue_sched_group = queue_sched_group,
+	.queue_lock_count = queue_lock_count,
+	.queue_to_u64 = queue_to_u64,
+	.queue_param_init = queue_param_init,
+	.queue_info = queue_info
+};
+
+/* Functions towards internal components */
+queue_fn_t queue_eventdev_fn = {
+	.init_global = queue_init_global,
+	.term_global = queue_term_global,
+	.init_local = queue_init_local,
+	.term_local = queue_term_local,
+	.get_pktout = queue_get_pktout,
+	.set_pktout = queue_set_pktout,
+	.get_pktin = queue_get_pktin,
+	.set_pktin = queue_set_pktin,
+	.set_enq_deq_fn = queue_set_enq_deq_func,
+	.orig_deq_multi = queue_orig_multi,
+	.timer_add = queue_timer_add,
+	.timer_rem = queue_timer_rem
+};

--- a/platform/linux-dpdk/odp_queue_if.c
+++ b/platform/linux-dpdk/odp_queue_if.c
@@ -26,6 +26,9 @@ const _odp_queue_api_fn_t *_odp_queue_api;
 extern const _odp_queue_api_fn_t queue_basic_api;
 extern const queue_fn_t queue_basic_fn;
 
+extern const _odp_queue_api_fn_t queue_eventdev_api;
+extern const queue_fn_t queue_eventdev_fn;
+
 const queue_fn_t *queue_fn;
 
 odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param)
@@ -103,6 +106,9 @@ int _odp_queue_init_global(void)
 	if (!strcmp(sched, "basic") || !strcmp(sched, "sp")) {
 		queue_fn = &queue_basic_fn;
 		_odp_queue_api = &queue_basic_api;
+	} else if (!strcmp(sched, "eventdev")) {
+		queue_fn = &queue_eventdev_fn;
+		_odp_queue_api = &queue_eventdev_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;

--- a/platform/linux-dpdk/odp_schedule_eventdev.c
+++ b/platform/linux-dpdk/odp_schedule_eventdev.c
@@ -1,0 +1,1085 @@
+/* Copyright (c) 2019, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp_eventdev_internal.h>
+#include <odp/api/ticketlock.h>
+#include <odp/api/thrmask.h>
+#include <odp_config_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_packet_io_internal.h>
+#include <odp_schedule_if.h>
+#include <odp_timer_internal.h>
+
+#include <rte_config.h>
+#include <rte_ethdev.h>
+#include <rte_eventdev.h>
+#include <rte_event_eth_rx_adapter.h>
+#include <rte_service.h>
+#include <rte_version.h>
+
+#include <inttypes.h>
+#include <string.h>
+
+/* Start of named groups in group mask arrays */
+#define SCHED_GROUP_NAMED (ODP_SCHED_GROUP_CONTROL + 1)
+
+/* Number of scheduling groups */
+#define NUM_SCHED_GRPS 32
+
+static inline odp_pktio_t index_to_pktio(int pktio_index)
+{
+	return (odp_pktio_t)(uintptr_t)pktio_index + 1;
+}
+
+static inline odp_queue_t queue_id_to_queue(uint8_t queue_id)
+{
+	return queue_from_qentry(qentry_from_index(queue_id));
+}
+
+static odp_event_t mbuf_to_event(struct rte_mbuf *mbuf)
+{
+	return (odp_event_t)mbuf;
+}
+
+static int link_port(uint8_t dev_id, uint8_t port_id, uint8_t queue_ids[],
+		     uint8_t priorities[], uint16_t nb_links, uint8_t link_now)
+{
+	int ret;
+
+	odp_ticketlock_lock(&eventdev_gbl->port_lock);
+
+	if (!eventdev_gbl->port[port_id].linked && !link_now) {
+		odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+		return 0;
+	}
+
+	ret = rte_event_port_link(dev_id, port_id, queue_ids, priorities,
+				  nb_links);
+	if (ret < 0 || (queue_ids && ret != nb_links)) {
+		ODP_ERR("rte_event_port_link failed: %d\n", ret);
+		odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+		return ret;
+	}
+
+	eventdev_gbl->port[port_id].linked = 1;
+
+	odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+
+	return ret;
+}
+
+static int unlink_port(uint8_t dev_id, uint8_t port_id, uint8_t queue_ids[],
+		       uint16_t nb_links)
+{
+	int ret;
+
+	odp_ticketlock_lock(&eventdev_gbl->port_lock);
+
+	if (!eventdev_gbl->port[port_id].linked) {
+		odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+		return 0;
+	}
+
+	ret = rte_event_port_unlink(dev_id, port_id, queue_ids, nb_links);
+	if (ret < 0) {
+		ODP_ERR("rte_event_port_unlink failed: %d\n", ret);
+		odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+		return ret;
+	}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(18, 11, 0, 0)
+	do {
+		ret = rte_event_port_unlinks_in_progress(dev_id, port_id);
+		if (ret < 0) {
+			ODP_ERR("rte_event_port_unlinks_in_progress failed: "
+				"%d\n", ret);
+			break;
+		}
+		odp_cpu_pause();
+	} while (ret > 0);
+#endif
+	if (queue_ids == NULL)
+		eventdev_gbl->port[port_id].linked = 0;
+
+	odp_ticketlock_unlock(&eventdev_gbl->port_lock);
+
+	return ret;
+}
+
+static int resume_scheduling(uint8_t dev_id, uint8_t port_id)
+{
+	uint8_t queue_ids[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	uint8_t priorities[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	int nb_links = 0;
+	int ret;
+	int i;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = 0; i < NUM_SCHED_GRPS; i++) {
+		int j;
+
+		if (!eventdev_gbl->grp[i].allocated ||
+		    !odp_thrmask_isset(&eventdev_gbl->grp[i].mask,
+				       eventdev_local.port_id))
+			continue;
+
+		for (j = 0; j < RTE_EVENT_MAX_QUEUES_PER_DEV; j++) {
+			queue_entry_t *queue = eventdev_gbl->grp[i].queue[j];
+
+			if (!queue)
+				continue;
+
+			queue_ids[nb_links] = queue->s.index;
+			priorities[nb_links] = queue->s.param.sched.prio;
+			nb_links++;
+		}
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+
+	if (!nb_links)
+		return 0;
+
+	ret = link_port(dev_id, port_id, queue_ids, priorities, nb_links, 1);
+	if (ret != nb_links)
+		return -1;
+
+	if (eventdev_local.started == 0) {
+		odp_atomic_inc_u32(&eventdev_gbl->num_started);
+		eventdev_local.started = 1;
+	}
+
+	return 0;
+}
+
+static int link_group(int group, const odp_thrmask_t *mask, odp_bool_t unlink)
+{
+	odp_thrmask_t new_mask;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_ids[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	uint8_t priorities[RTE_EVENT_MAX_QUEUES_PER_DEV];
+	int nb_links = 0;
+	int ret;
+	int thr;
+	int i;
+
+	for (i = 0; i < RTE_EVENT_MAX_QUEUES_PER_DEV; i++) {
+		queue_entry_t *queue = eventdev_gbl->grp[group].queue[i];
+
+		if (queue == NULL)
+			continue;
+
+		queue_ids[nb_links] = queue->s.index;
+		priorities[nb_links] = queue->s.param.sched.prio;
+		nb_links++;
+	}
+
+	new_mask = *mask;
+	thr = odp_thrmask_first(&new_mask);
+	while (thr >= 0) {
+		uint8_t port_id = thr;
+
+		thr = odp_thrmask_next(&new_mask, thr);
+
+		if (unlink)
+			ret = unlink_port(dev_id, port_id, queue_ids, nb_links);
+		else
+			ret = link_port(dev_id, port_id, queue_ids, priorities,
+					nb_links, 0);
+		if (ret < 0) {
+			ODP_ERR("Modifying port links failed\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int rx_adapter_create(uint8_t dev_id, uint8_t rx_adapter_id,
+			     const struct rte_event_dev_config *config)
+{
+	struct rte_event_port_conf port_config;
+	uint32_t capa;
+	int ret;
+
+	ret = rte_event_eth_rx_adapter_caps_get(dev_id, rx_adapter_id, &capa);
+	if (ret) {
+		ODP_ERR("rte_event_eth_rx_adapter_caps_get failed: %d\n", ret);
+		return -1;
+	}
+	if ((capa & RTE_EVENT_ETH_RX_ADAPTER_CAP_MULTI_EVENTQ) == 0)
+		eventdev_gbl->rx_adapter.single_queue = 1;
+
+	memset(&port_config, 0, sizeof(struct rte_event_port_conf));
+	port_config.new_event_threshold = config->nb_events_limit;
+	port_config.dequeue_depth = config->nb_event_port_dequeue_depth;
+	port_config.enqueue_depth = config->nb_event_port_enqueue_depth;
+	ret = rte_event_eth_rx_adapter_create(rx_adapter_id, dev_id,
+					      &port_config);
+	if (ret) {
+		ODP_ERR("rte_event_eth_rx_adapter_create failed: %d\n", ret);
+		return -1;
+	}
+
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_STOPPED;
+
+	return 0;
+}
+
+static int rx_adapter_add_queues(uint8_t rx_adapter_id, uint8_t port_id,
+				 int num_pktin, int pktin_idx[],
+				 odp_queue_t queues[])
+{
+	int num_dummy_links = eventdev_gbl->config.nb_event_queues;
+	uint8_t dummy_links[num_dummy_links];
+	int ret = 0;
+	int i;
+
+	/* SW eventdev requires that all queues have ports linked */
+	num_dummy_links = dummy_link_queues(eventdev_gbl->dev_id, dummy_links,
+					    num_dummy_links);
+
+	for (i = 0; i < num_pktin; i++) {
+		queue_entry_t *queue = qentry_from_handle(queues[i]);
+		struct rte_event_eth_rx_adapter_queue_conf qconf;
+		struct rte_event ev;
+		int32_t rx_queue_id = pktin_idx[i];
+
+		memset(&ev, 0, sizeof(struct rte_event));
+		ev.queue_id = queue->s.index;
+		ev.flow_id = 0;
+		ev.sched_type = queue->s.param.sched.prio;
+		ev.sched_type = event_schedule_type(queue->s.param.sched.sync);
+		ev.priority = 0;
+
+		memset(&qconf, 0,
+		       sizeof(struct rte_event_eth_rx_adapter_queue_conf));
+		qconf.ev = ev;
+		qconf.rx_queue_flags = 0;
+		qconf.servicing_weight = 1;
+
+		if (eventdev_gbl->rx_adapter.single_queue)
+			rx_queue_id = -1;
+
+		ret = rte_event_eth_rx_adapter_queue_add(rx_adapter_id, port_id,
+							 rx_queue_id, &qconf);
+		if (ret) {
+			ODP_ERR("rte_event_eth_rx_adapter_queue_add failed\n");
+			return -1;
+		}
+
+		if (eventdev_gbl->rx_adapter.single_queue)
+			break;
+	}
+
+	if (dummy_unlink_queues(eventdev_gbl->dev_id, dummy_links,
+				num_dummy_links))
+		return -1;
+
+	return ret;
+}
+
+int rx_adapter_close(void)
+{
+	uint16_t port_id;
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+	int ret = 0;
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_INIT)
+		return ret;
+
+	if (eventdev_gbl->rx_adapter.status != RX_ADAPTER_STOPPED &&
+	    rte_event_eth_rx_adapter_stop(rx_adapter_id)) {
+		ODP_ERR("Failed to stop RX adapter\n");
+		ret = -1;
+	}
+
+	RTE_ETH_FOREACH_DEV(port_id) {
+		rte_eth_dev_close(port_id);
+	}
+
+	eventdev_gbl->rx_adapter.status = RX_ADAPTER_INIT;
+
+	return ret;
+}
+
+void rx_adapter_port_stop(uint16_t port_id)
+{
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+
+	if (rte_event_eth_rx_adapter_queue_del(rx_adapter_id, port_id, -1))
+		ODP_ERR("Failed to delete RX queue\n");
+
+	rte_eth_dev_stop(port_id);
+}
+
+static int schedule_init_global(void)
+{
+	ODP_DBG("Using eventdev scheduler\n");
+	return 0;
+}
+
+static int schedule_init_local(void)
+{
+	return 0;
+}
+
+static int schedule_term_local(void)
+{
+	return 0;
+}
+
+static int schedule_term_global(void)
+{
+	return 0;
+}
+
+static uint32_t schedule_max_ordered_locks(void)
+{
+	return 1;
+}
+
+static inline int schedule_min_prio(void)
+{
+	return 0;
+}
+
+static inline  int schedule_max_prio(void)
+{
+	return eventdev_gbl->num_prio - 1;
+}
+
+static inline  int schedule_default_prio(void)
+{
+	return schedule_max_prio() / 2;
+}
+
+static int schedule_init_queue(uint32_t qi,
+			       const odp_schedule_param_t *sched_param)
+{
+	queue_entry_t *queue = qentry_from_index(qi);
+	odp_thrmask_t mask;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_id = queue->s.index;
+	uint8_t priority = sched_param->prio;
+	int thr;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	eventdev_gbl->grp[sched_param->group].queue[queue_id] = queue;
+
+	mask = eventdev_gbl->grp[sched_param->group].mask;
+	thr = odp_thrmask_first(&mask);
+	while (0 <= thr) {
+		link_port(dev_id, thr, &queue_id, &priority, 1, 0);
+		thr = odp_thrmask_next(&mask, thr);
+	}
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+static void schedule_destroy_queue(uint32_t qi)
+{
+	queue_entry_t *queue = qentry_from_index(qi);
+	odp_thrmask_t mask;
+	odp_schedule_group_t group = queue->s.param.sched.group;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t queue_id = queue->s.index;
+	int thr;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	eventdev_gbl->grp[group].queue[queue_id] = NULL;
+
+	mask = eventdev_gbl->grp[group].mask;
+	thr = odp_thrmask_first(&mask);
+	while (0 <= thr) {
+		unlink_port(dev_id, thr, &queue_id, 1);
+		thr = odp_thrmask_next(&mask, thr);
+	}
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+}
+
+static void schedule_pktio_start(int pktio_index, int num_pktin,
+				 int pktin_idx[], odp_queue_t queue[])
+{
+	pktio_entry_t *entry = get_pktio_entry(index_to_pktio(pktio_index));
+	uint16_t port_id = dpdk_pktio_port_id(entry);
+	uint8_t rx_adapter_id = eventdev_gbl->rx_adapter.id;
+
+	/* All eventdev pktio devices should to be started before calling
+	 * odp_schedule(). This is due to the SW eventdev requirement that all
+	 * event queues are linked when rte_event_eth_rx_adapter_queue_add() is
+	 * called. */
+	if (odp_atomic_load_u32(&eventdev_gbl->num_started))
+		ODP_PRINT("All ODP pktio devices used by the scheduler should "
+			  "be started before calling odp_schedule() for the "
+			  "first time.\n");
+
+	eventdev_gbl->pktio[port_id] = entry;
+
+	odp_ticketlock_lock(&eventdev_gbl->rx_adapter.lock);
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_INIT &&
+	    rx_adapter_create(eventdev_gbl->dev_id, rx_adapter_id,
+			      &eventdev_gbl->config))
+		ODP_ABORT("Creating eventdev RX adapter failed\n");
+
+	if (rx_adapter_add_queues(rx_adapter_id, port_id, num_pktin, pktin_idx,
+				  queue))
+		ODP_ABORT("Adding RX adapter queues failed\n");
+
+	if (eventdev_gbl->rx_adapter.status == RX_ADAPTER_STOPPED) {
+		uint32_t service_id = 0;
+		int ret;
+
+		ret = rte_event_eth_rx_adapter_service_id_get(rx_adapter_id,
+							      &service_id);
+		if (ret && ret != -ESRCH) {
+			ODP_ABORT("Unable to retrieve service ID\n");
+		} else if (!ret) {
+			if (service_setup(service_id))
+				ODP_ABORT("Unable to start RX service\n");
+		}
+
+		if (rte_event_eth_rx_adapter_start(rx_adapter_id))
+			ODP_ABORT("Unable to start RX adapter\n");
+
+		eventdev_gbl->rx_adapter.status = RX_ADAPTER_RUNNING;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->rx_adapter.lock);
+}
+
+static inline int classify_pkts(odp_packet_t packets[], int num)
+{
+	odp_packet_t pkt;
+	odp_packet_hdr_t *pkt_hdr;
+	int i, num_rx, num_ev, num_dst;
+	odp_queue_t cur_queue;
+	odp_event_t ev[num];
+	odp_queue_t dst[num];
+	int dst_idx[num];
+
+	num_rx = 0;
+	num_dst = 0;
+	num_ev = 0;
+
+	/* Some compilers need this dummy initialization */
+	cur_queue = ODP_QUEUE_INVALID;
+
+	for (i = 0; i < num; i++) {
+		pkt = packets[i];
+		pkt_hdr = packet_hdr(pkt);
+
+		if (odp_unlikely(pkt_hdr->p.input_flags.dst_queue)) {
+			/* Sort events for enqueue multi operation(s) */
+			if (odp_unlikely(num_dst == 0)) {
+				num_dst = 1;
+				cur_queue = pkt_hdr->dst_queue;
+				dst[0] = cur_queue;
+				dst_idx[0] = 0;
+			}
+
+			ev[num_ev] = odp_packet_to_event(pkt);
+
+			if (cur_queue != pkt_hdr->dst_queue) {
+				cur_queue = pkt_hdr->dst_queue;
+				dst[num_dst] = cur_queue;
+				dst_idx[num_dst] = num_ev;
+				num_dst++;
+			}
+
+			num_ev++;
+			continue;
+		}
+		packets[num_rx++] = pkt;
+	}
+
+	/* Optimization for the common case */
+	if (odp_likely(num_dst == 0))
+		return num_rx;
+
+	for (i = 0; i < num_dst; i++) {
+		int num_enq, ret;
+		int idx = dst_idx[i];
+
+		if (i == (num_dst - 1))
+			num_enq = num_ev - idx;
+		else
+			num_enq = dst_idx[i + 1] - idx;
+
+		ret = odp_queue_enq_multi(dst[i], &ev[idx], num_enq);
+
+		if (ret < 0)
+			ret = 0;
+
+		if (ret < num_enq)
+			odp_event_free_multi(&ev[idx + ret], num_enq - ret);
+	}
+
+	return num_rx;
+}
+
+static inline uint16_t event_input(struct rte_event ev[], odp_event_t out_ev[],
+				   uint16_t nb_events, odp_queue_t *out_queue)
+{
+	struct rte_mbuf *pkt_table[nb_events];
+	uint16_t num_pkts = 0;
+	uint16_t num_events = 0;
+	uint16_t i;
+	uint8_t first_queue = ev[0].queue_id;
+
+	for (i = 0; i < nb_events;  i++) {
+		struct rte_event *event = &ev[i];
+
+		if (odp_unlikely(event->queue_id != first_queue)) {
+			uint16_t cache_idx, j;
+
+			eventdev_local.cache.idx = 0;
+			for (j = i; j < nb_events; j++) {
+				cache_idx = eventdev_local.cache.count;
+				eventdev_local.cache.event[cache_idx] = ev[j];
+				eventdev_local.cache.count++;
+			}
+			break;
+		}
+
+		/* Packets have to be initialized */
+		if (event->event_type == RTE_EVENT_TYPE_ETH_RX_ADAPTER) {
+			pkt_table[num_pkts++] = event->mbuf;
+			continue;
+		}
+
+		out_ev[num_events++] = mbuf_to_event(event->mbuf);
+	}
+
+	if (num_pkts) {
+		pktio_entry_t *entry = eventdev_gbl->pktio[pkt_table[0]->port];
+
+		num_pkts = input_pkts(entry, (odp_packet_t *)pkt_table,
+				      num_pkts);
+
+		if (!odp_global_ro.init_param.not_used.feat.cls)
+			num_pkts = classify_pkts((odp_packet_t *)pkt_table,
+						 num_pkts);
+
+		for (i = 0; i < num_pkts; i++)
+			out_ev[num_events++] = mbuf_to_event(pkt_table[i]);
+	}
+
+	if (out_queue && num_events)
+		*out_queue = queue_id_to_queue(first_queue);
+
+	return num_events;
+}
+
+/* Fetch consecutive events from the same queue from cache */
+static inline uint16_t input_cached(odp_event_t out_ev[], unsigned int max_num,
+				    odp_queue_t *out_queue)
+{
+	struct rte_event ev[max_num];
+	uint16_t idx = eventdev_local.cache.idx;
+	uint16_t i;
+	uint8_t first_queue = eventdev_local.cache.event[idx].queue_id;
+
+	for (i = 0; i < max_num && eventdev_local.cache.count; i++) {
+		uint16_t idx = eventdev_local.cache.idx;
+		struct rte_event *event = &eventdev_local.cache.event[idx];
+
+		if (odp_unlikely(event->queue_id != first_queue))
+			break;
+
+		eventdev_local.cache.idx++;
+		eventdev_local.cache.count--;
+		ev[i] = *event;
+	}
+
+	return event_input(ev, out_ev, i, out_queue);
+}
+
+static inline int schedule_loop(odp_queue_t *out_queue, uint64_t wait,
+				odp_event_t out_ev[], unsigned int max_num)
+{
+	odp_time_t next, wtime;
+	struct rte_event ev[max_num];
+	int first = 1;
+	uint16_t num_deq;
+	uint8_t dev_id = eventdev_gbl->dev_id;
+	uint8_t port_id = eventdev_local.port_id;
+
+	if (odp_unlikely(port_id >= eventdev_gbl->num_event_ports)) {
+		ODP_ERR("Max %" PRIu8 " scheduled workers supported\n",
+			eventdev_gbl->num_event_ports);
+		return 0;
+	}
+
+	/* Check that port is linked */
+	if (odp_unlikely(!eventdev_gbl->port[port_id].linked &&
+			 !eventdev_local.paused)) {
+		if (resume_scheduling(dev_id, port_id))
+			return 0;
+	}
+
+	if (odp_unlikely(max_num > MAX_SCHED_BURST))
+		max_num = MAX_SCHED_BURST;
+
+	if (odp_unlikely(eventdev_local.cache.count)) {
+		num_deq = input_cached(out_ev, max_num, out_queue);
+	} else {
+		while (1) {
+			num_deq = rte_event_dequeue_burst(dev_id, port_id, ev,
+							  max_num, 0);
+			if (num_deq) {
+				num_deq = event_input(ev, out_ev, num_deq,
+						      out_queue);
+				timer_run(2);
+				/* Classifier may enqueue events back to
+				 * eventdev */
+				if (odp_unlikely(num_deq == 0))
+					continue;
+				break;
+			}
+			timer_run(1);
+
+			if (wait == ODP_SCHED_WAIT)
+				continue;
+
+			if (wait == ODP_SCHED_NO_WAIT)
+				return 0;
+
+			if (first) {
+				wtime = odp_time_local_from_ns(wait);
+				next = odp_time_sum(odp_time_local(), wtime);
+				first = 0;
+				continue;
+			}
+
+			if (odp_time_cmp(next, odp_time_local()) < 0)
+				return 0;
+		}
+	}
+
+	return num_deq;
+}
+
+static odp_event_t schedule(odp_queue_t *out_queue, uint64_t wait)
+{
+	odp_event_t ev;
+
+	ev = ODP_EVENT_INVALID;
+
+	schedule_loop(out_queue, wait, &ev, 1);
+
+	return ev;
+}
+
+static int schedule_multi(odp_queue_t *out_queue, uint64_t wait,
+			  odp_event_t events[], int num)
+{
+	return schedule_loop(out_queue, wait, events, num);
+}
+
+static int schedule_multi_wait(odp_queue_t *out_queue, odp_event_t events[],
+			       int num)
+{
+	return schedule_loop(out_queue, ODP_SCHED_WAIT, events, num);
+}
+
+static int schedule_multi_no_wait(odp_queue_t *out_queue, odp_event_t events[],
+				  int num)
+{
+	return schedule_loop(out_queue, ODP_SCHED_NO_WAIT, events, num);
+}
+
+static void schedule_pause(void)
+{
+	if (unlink_port(eventdev_gbl->dev_id,
+			eventdev_local.port_id, NULL, 0) < 0)
+		ODP_ERR("Unable to pause scheduling\n");
+
+	eventdev_local.paused = 1;
+}
+
+static void schedule_resume(void)
+{
+	if (resume_scheduling(eventdev_gbl->dev_id, eventdev_local.port_id))
+		ODP_ERR("Unable to resume scheduling\n");
+
+	eventdev_local.paused = 0;
+}
+
+static void schedule_release_atomic(void)
+{
+}
+
+static void schedule_release_ordered(void)
+{
+}
+
+static uint64_t schedule_wait_time(uint64_t ns)
+{
+	return ns;
+}
+
+static inline void grp_update_mask(int grp, const odp_thrmask_t *new_mask)
+{
+	odp_thrmask_copy(&eventdev_gbl->grp[grp].mask, new_mask);
+}
+
+static int schedule_thr_add(odp_schedule_group_t group, int thr)
+{
+	odp_thrmask_t mask;
+	odp_thrmask_t new_mask;
+
+	if (group < 0 || group >= SCHED_GROUP_NAMED)
+		return -1;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, thr);
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	odp_thrmask_or(&new_mask, &eventdev_gbl->grp[group].mask, &mask);
+	grp_update_mask(group, &new_mask);
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+static int schedule_thr_rem(odp_schedule_group_t group, int thr)
+{
+	odp_thrmask_t mask;
+	odp_thrmask_t new_mask;
+
+	if (group < 0 || group >= SCHED_GROUP_NAMED)
+		return -1;
+
+	odp_thrmask_zero(&mask);
+	odp_thrmask_set(&mask, thr);
+	odp_thrmask_xor(&new_mask, &mask, &eventdev_gbl->mask_all);
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	odp_thrmask_and(&new_mask, &eventdev_gbl->grp[group].mask,
+			&new_mask);
+	grp_update_mask(group, &new_mask);
+
+	unlink_port(eventdev_gbl->dev_id, thr, NULL, 0);
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+
+	return 0;
+}
+
+/* This function is a no-op */
+static void schedule_prefetch(int num ODP_UNUSED)
+{
+}
+
+static int schedule_num_prio(void)
+{
+	return eventdev_gbl->num_prio;
+}
+
+static int schedule_num_grps(void)
+{
+	return NUM_SCHED_GRPS;
+}
+
+static odp_schedule_group_t schedule_group_create(const char *name,
+						  const odp_thrmask_t *mask)
+{
+	odp_schedule_group_t group = ODP_SCHED_GROUP_INVALID;
+	int i;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = SCHED_GROUP_NAMED; i < NUM_SCHED_GRPS; i++) {
+		if (!eventdev_gbl->grp[i].allocated) {
+			char *grp_name = eventdev_gbl->grp[i].name;
+
+			if (name == NULL) {
+				grp_name[0] = 0;
+			} else {
+				strncpy(grp_name, name,
+					ODP_SCHED_GROUP_NAME_LEN - 1);
+				grp_name[ODP_SCHED_GROUP_NAME_LEN - 1] = 0;
+			}
+
+			grp_update_mask(i, mask);
+			group = (odp_schedule_group_t)i;
+			eventdev_gbl->grp[i].allocated = 1;
+			break;
+		}
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return group;
+}
+
+static int schedule_group_destroy(odp_schedule_group_t group)
+{
+	odp_thrmask_t zero;
+	int ret;
+
+	odp_thrmask_zero(&zero);
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		grp_update_mask(group, &zero);
+		memset(eventdev_gbl->grp[group].name, 0,
+		       ODP_SCHED_GROUP_NAME_LEN);
+		eventdev_gbl->grp[group].allocated = 0;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static odp_schedule_group_t schedule_group_lookup(const char *name)
+{
+	odp_schedule_group_t group = ODP_SCHED_GROUP_INVALID;
+	int i;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	for (i = SCHED_GROUP_NAMED; i < NUM_SCHED_GRPS; i++) {
+		if (strcmp(name, eventdev_gbl->grp[i].name) == 0) {
+			group = (odp_schedule_group_t)i;
+			break;
+		}
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return group;
+}
+
+static int schedule_group_join(odp_schedule_group_t group,
+			       const odp_thrmask_t *mask)
+{
+	int ret = 0;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		odp_thrmask_t new_mask;
+		odp_thrmask_t link_mask;
+
+		odp_thrmask_and(&link_mask, &eventdev_gbl->grp[group].mask,
+				mask);
+		odp_thrmask_xor(&link_mask, &link_mask, mask);
+		odp_thrmask_or(&new_mask, &eventdev_gbl->grp[group].mask,
+			       mask);
+		grp_update_mask(group, &new_mask);
+
+		ret = link_group(group, &link_mask, 0);
+	} else {
+		ret = -1;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_leave(odp_schedule_group_t group,
+				const odp_thrmask_t *mask)
+{
+	odp_thrmask_t new_mask;
+	odp_thrmask_t unlink_mask;
+	int ret = 0;
+
+	odp_thrmask_xor(&new_mask, mask, &eventdev_gbl->mask_all);
+	odp_thrmask_and(&unlink_mask, mask, &eventdev_gbl->mask_all);
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		odp_thrmask_and(&unlink_mask, &eventdev_gbl->grp[group].mask,
+				&unlink_mask);
+		odp_thrmask_and(&new_mask, &eventdev_gbl->grp[group].mask,
+				&new_mask);
+		grp_update_mask(group, &new_mask);
+
+		ret = link_group(group, &unlink_mask, 1);
+	} else {
+		ret = -1;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_thrmask(odp_schedule_group_t group,
+				  odp_thrmask_t *thrmask)
+{
+	int ret;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		*thrmask = eventdev_gbl->grp[group].mask;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static int schedule_group_info(odp_schedule_group_t group,
+			       odp_schedule_group_info_t *info)
+{
+	int ret;
+
+	odp_ticketlock_lock(&eventdev_gbl->grp_lock);
+
+	if (group < NUM_SCHED_GRPS && group >= SCHED_GROUP_NAMED &&
+	    eventdev_gbl->grp[group].allocated) {
+		info->name    = eventdev_gbl->grp[group].name;
+		info->thrmask = eventdev_gbl->grp[group].mask;
+		ret = 0;
+	} else {
+		ret = -1;
+	}
+
+	odp_ticketlock_unlock(&eventdev_gbl->grp_lock);
+	return ret;
+}
+
+static void schedule_order_lock(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_unlock(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_unlock_lock(uint32_t unlock_index ODP_UNUSED,
+				       uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_lock_start(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void schedule_order_lock_wait(uint32_t lock_index ODP_UNUSED)
+{
+}
+
+static void order_lock(void)
+{
+}
+
+static void order_unlock(void)
+{
+}
+
+static int schedule_capability(odp_schedule_capability_t *capa)
+{
+	uint16_t max_sched;
+
+	memset(capa, 0, sizeof(odp_schedule_capability_t));
+
+	max_sched = RTE_MAX(RTE_MAX(eventdev_gbl->event_queue.num_atomic,
+				    eventdev_gbl->event_queue.num_ordered),
+			    eventdev_gbl->event_queue.num_parallel);
+	capa->max_queues        = RTE_MIN(ODP_CONFIG_QUEUES, max_sched);
+	capa->max_queue_size    = eventdev_gbl->config.nb_events_limit;
+	capa->max_ordered_locks = schedule_max_ordered_locks();
+	capa->max_groups        = schedule_num_grps();
+	capa->max_prios         = odp_schedule_num_prio();
+
+	return 0;
+}
+
+static void schedule_config_init(odp_schedule_config_t *config)
+{
+	odp_schedule_capability_t capa;
+
+	schedule_capability(&capa);
+
+	memset(config, 0, sizeof(odp_schedule_config_t));
+
+	config->num_queues = capa.max_queues;
+	config->queue_size = capa.max_queue_size / 2;
+	config->max_flow_id = 0;
+}
+
+static int schedule_config(const odp_schedule_config_t *config)
+{
+	(void)config;
+
+	return 0;
+}
+
+/* Fill in scheduler interface */
+const schedule_fn_t schedule_eventdev_fn = {
+	.pktio_start = schedule_pktio_start,
+	.thr_add = schedule_thr_add,
+	.thr_rem = schedule_thr_rem,
+	.num_grps = schedule_num_grps,
+	.init_queue = schedule_init_queue,
+	.destroy_queue = schedule_destroy_queue,
+	.sched_queue = NULL,
+	.ord_enq_multi = NULL,
+	.init_global = schedule_init_global,
+	.term_global = schedule_term_global,
+	.init_local  = schedule_init_local,
+	.term_local  = schedule_term_local,
+	.order_lock = order_lock,
+	.order_unlock = order_unlock,
+	.max_ordered_locks = schedule_max_ordered_locks,
+	.get_config = NULL
+};
+
+/* Fill in scheduler API calls */
+const schedule_api_t schedule_eventdev_api = {
+	.schedule_wait_time       = schedule_wait_time,
+	.schedule_capability      = schedule_capability,
+	.schedule_config_init     = schedule_config_init,
+	.schedule_config          = schedule_config,
+	.schedule                 = schedule,
+	.schedule_multi           = schedule_multi,
+	.schedule_multi_wait      = schedule_multi_wait,
+	.schedule_multi_no_wait   = schedule_multi_no_wait,
+	.schedule_pause           = schedule_pause,
+	.schedule_resume          = schedule_resume,
+	.schedule_release_atomic  = schedule_release_atomic,
+	.schedule_release_ordered = schedule_release_ordered,
+	.schedule_prefetch        = schedule_prefetch,
+	.schedule_min_prio        = schedule_min_prio,
+	.schedule_max_prio        = schedule_max_prio,
+	.schedule_default_prio    = schedule_default_prio,
+	.schedule_num_prio        = schedule_num_prio,
+	.schedule_group_create    = schedule_group_create,
+	.schedule_group_destroy   = schedule_group_destroy,
+	.schedule_group_lookup    = schedule_group_lookup,
+	.schedule_group_join      = schedule_group_join,
+	.schedule_group_leave     = schedule_group_leave,
+	.schedule_group_thrmask   = schedule_group_thrmask,
+	.schedule_group_info      = schedule_group_info,
+	.schedule_order_lock      = schedule_order_lock,
+	.schedule_order_unlock    = schedule_order_unlock,
+	.schedule_order_unlock_lock  = schedule_order_unlock_lock,
+	.schedule_order_lock_start   = schedule_order_lock_start,
+	.schedule_order_lock_wait    = schedule_order_lock_wait
+};

--- a/platform/linux-dpdk/odp_schedule_if.c
+++ b/platform/linux-dpdk/odp_schedule_if.c
@@ -19,6 +19,9 @@ extern const schedule_api_t schedule_sp_api;
 extern const schedule_fn_t schedule_basic_fn;
 extern const schedule_api_t schedule_basic_api;
 
+extern const schedule_fn_t schedule_eventdev_fn;
+extern const schedule_api_t schedule_eventdev_api;
+
 const schedule_fn_t *sched_fn;
 const schedule_api_t *sched_api;
 
@@ -214,6 +217,9 @@ int _odp_schedule_init_global(void)
 	} else if (!strcmp(sched, "sp")) {
 		sched_fn = &schedule_sp_fn;
 		sched_api = &schedule_sp_api;
+	} else if (!strcmp(sched, "eventdev")) {
+		sched_fn = &schedule_eventdev_fn;
+		sched_api = &schedule_eventdev_api;
 	} else {
 		ODP_ABORT("Unknown scheduler specified via ODP_SCHEDULER\n");
 		return -1;

--- a/platform/linux-dpdk/odp_thread.c
+++ b/platform/linux-dpdk/odp_thread.c
@@ -143,7 +143,6 @@ int odp_thread_init_local(odp_thread_type_t type)
 {
 	int id;
 	int cpu;
-	struct rte_config *cfg = rte_eal_get_configuration();
 	int group_all, group_worker, group_control;
 
 	group_all = 1;
@@ -179,9 +178,6 @@ int odp_thread_init_local(odp_thread_type_t type)
 	thread_globals->thr[id].cpu  = cpu;
 	thread_globals->thr[id].type = type;
 	RTE_PER_LCORE(_lcore_id) = cpu;
-	if (cfg->lcore_role[cpu] == ROLE_RTE)
-		ODP_ERR("There is a thread already running on core %d\n", cpu);
-	cfg->lcore_role[cpu] = ROLE_RTE;
 
 	_odp_this_thread = &thread_globals->thr[id];
 


### PR DESCRIPTION
Add DPDK eventdev based new scheduler and queue implementations. The initial
implementation has been validated using only the standard software eventdev
poll mode driver with DPDK v18.11.

To use eventdev one must set ODP_SCHEDULER environment variable to
"eventdev" and provide the necessary platform parameters to DPDK.