### PR TITLE
[PATCH v2] linux-dpdk: eventdev: use correct priority value

### DIFF
--- a/platform/linux-dpdk/include/odp_eventdev_internal.h
+++ b/platform/linux-dpdk/include/odp_eventdev_internal.h
@@ -63,6 +63,10 @@ struct queue_entry_s {
 	uint32_t          index;
 	odp_queue_type_t  type;
 
+	struct {
+		uint8_t prio;
+	} eventdev;
+
 	ring_mpmc_t       ring_mpmc;
 
 	odp_ticketlock_t  lock;

--- a/platform/linux-dpdk/odp_queue_eventdev.c
+++ b/platform/linux-dpdk/odp_queue_eventdev.c
@@ -1006,7 +1006,7 @@ static inline int _sched_queue_enq_multi(odp_queue_t handle,
 
 	sched = event_schedule_type(queue->s.param.sched.sync);
 	queue_id = queue->s.index;
-	priority = queue->s.param.sched.prio;
+	priority = queue->s.eventdev.prio;
 
 	UNLOCK(queue);
 
@@ -1067,6 +1067,10 @@ static int queue_init(queue_entry_t *queue, const char *name,
 	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
 	if (queue->s.param.sched.lock_count > sched_fn->max_ordered_locks())
 		return -1;
+
+	/* Convert ODP priority to eventdev priority:
+	 *     ODP_SCHED_PRIO_HIGHEST == RTE_EVENT_DEV_PRIORITY_LOWEST */
+	queue->s.eventdev.prio = odp_schedule_max_prio() - param->sched.prio;
 
 	if (queue_type == ODP_QUEUE_TYPE_SCHED)
 		queue->s.param.deq_mode = ODP_QUEUE_OP_DISABLED;

--- a/platform/linux-dpdk/odp_schedule_eventdev.c
+++ b/platform/linux-dpdk/odp_schedule_eventdev.c
@@ -136,7 +136,7 @@ static int resume_scheduling(uint8_t dev_id, uint8_t port_id)
 				continue;
 
 			queue_ids[nb_links] = queue->s.index;
-			priorities[nb_links] = queue->s.param.sched.prio;
+			priorities[nb_links] = queue->s.eventdev.prio;
 			nb_links++;
 		}
 	}
@@ -176,7 +176,7 @@ static int link_group(int group, const odp_thrmask_t *mask, odp_bool_t unlink)
 			continue;
 
 		queue_ids[nb_links] = queue->s.index;
-		priorities[nb_links] = queue->s.param.sched.prio;
+		priorities[nb_links] = queue->s.eventdev.prio;
 		nb_links++;
 	}
 
@@ -254,9 +254,8 @@ static int rx_adapter_add_queues(uint8_t rx_adapter_id, uint8_t port_id,
 		memset(&ev, 0, sizeof(struct rte_event));
 		ev.queue_id = queue->s.index;
 		ev.flow_id = 0;
-		ev.sched_type = queue->s.param.sched.prio;
+		ev.priority = queue->s.eventdev.prio;
 		ev.sched_type = event_schedule_type(queue->s.param.sched.sync);
-		ev.priority = 0;
 
 		memset(&qconf, 0,
 		       sizeof(struct rte_event_eth_rx_adapter_queue_conf));


### PR DESCRIPTION
ODP_SCHED_PRIO_HIGHEST == RTE_EVENT_DEV_PRIORITY_LOWEST, so ODP priority
has to be converted into eventdev priority.

Signed-off-by: Matias Elo <matias.elo@nokia.com>