### PR TITLE
[PATCH v2] linux-dpdk: pktio: fix rx/tx checksum offload

### DIFF
--- a/platform/linux-dpdk/odp_packet_dpdk.c
+++ b/platform/linux-dpdk/odp_packet_dpdk.c
@@ -241,6 +241,8 @@ static int dpdk_setup_eth_dev(pktio_entry_t *pktio_entry,
 	struct rte_eth_conf eth_conf;
 	uint64_t rss_hf_capa = dev_info->flow_type_rss_offloads;
 	pool_t *pool = pool_entry_from_hdl(pktio_entry->s.pool);
+	uint64_t rx_offloads = 0;
+	uint64_t tx_offloads = 0;
 
 	memset(&rss_conf, 0, sizeof(struct rte_eth_rss_conf));
 
@@ -259,6 +261,36 @@ static int dpdk_setup_eth_dev(pktio_entry_t *pktio_entry,
 	eth_conf.rxmode.mq_mode = ETH_MQ_RX_RSS;
 	eth_conf.txmode.mq_mode = ETH_MQ_TX_NONE;
 	eth_conf.rx_adv_conf.rss_conf = rss_conf;
+
+	/* Setup RX checksum offloads */
+	if (pktio_entry->s.config.pktin.bit.ipv4_chksum)
+		rx_offloads |= DEV_RX_OFFLOAD_IPV4_CKSUM;
+
+	if (pktio_entry->s.config.pktin.bit.udp_chksum)
+		rx_offloads |= DEV_RX_OFFLOAD_UDP_CKSUM;
+
+	if (pktio_entry->s.config.pktin.bit.tcp_chksum)
+		rx_offloads |= DEV_RX_OFFLOAD_TCP_CKSUM;
+
+	eth_conf.rxmode.offloads = rx_offloads;
+
+	/* Setup TX checksum offloads */
+	if (pktio_entry->s.config.pktout.bit.ipv4_chksum_ena)
+		tx_offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
+
+	if (pktio_entry->s.config.pktout.bit.udp_chksum_ena)
+		tx_offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
+
+	if (pktio_entry->s.config.pktout.bit.tcp_chksum_ena)
+		tx_offloads |= DEV_TX_OFFLOAD_TCP_CKSUM;
+
+	if (pktio_entry->s.config.pktout.bit.sctp_chksum_ena)
+		tx_offloads |= DEV_TX_OFFLOAD_SCTP_CKSUM;
+
+	eth_conf.txmode.offloads = tx_offloads;
+
+	if (tx_offloads)
+		pktio_entry->s.chksum_insert_ena = 1;
 
 	/* RX packet len same size as pool segment minus headroom and double
 	 * VLAN tag
@@ -707,37 +739,15 @@ static int dpdk_setup_eth_tx(pktio_entry_t *pktio_entry,
 			     const pkt_dpdk_t *pkt_dpdk,
 			     const struct rte_eth_dev_info *dev_info)
 {
-	struct rte_eth_txconf txconf;
-	uint64_t tx_offloads;
 	uint32_t i;
 	int ret;
 	uint16_t port_id = pkt_dpdk->port_id;
-
-	txconf = dev_info->default_txconf;
-
-	tx_offloads = 0;
-	if (pktio_entry->s.config.pktout.bit.ipv4_chksum_ena)
-		tx_offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
-
-	if (pktio_entry->s.config.pktout.bit.udp_chksum_ena)
-		tx_offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
-
-	if (pktio_entry->s.config.pktout.bit.tcp_chksum_ena)
-		tx_offloads |= DEV_TX_OFFLOAD_TCP_CKSUM;
-
-	if (pktio_entry->s.config.pktout.bit.sctp_chksum_ena)
-		tx_offloads |= DEV_TX_OFFLOAD_SCTP_CKSUM;
-
-	txconf.offloads = tx_offloads;
-
-	if (tx_offloads)
-		pktio_entry->s.chksum_insert_ena = 1;
 
 	for (i = 0; i < pktio_entry->s.num_out_queue; i++) {
 		ret = rte_eth_tx_queue_setup(port_id, i,
 					     pkt_dpdk->opt.num_tx_desc,
 					     rte_eth_dev_socket_id(port_id),
-					     &txconf);
+					     &dev_info->default_txconf);
 		if (ret < 0) {
 			ODP_ERR("Queue setup failed: err=%d, port=%" PRIu8 "\n",
 				ret, port_id);
@@ -753,7 +763,6 @@ static int dpdk_setup_eth_rx(const pktio_entry_t *pktio_entry,
 			     const struct rte_eth_dev_info *dev_info)
 {
 	struct rte_eth_rxconf rxconf;
-	uint64_t rx_offloads;
 	uint32_t i;
 	int ret;
 	uint16_t port_id = pkt_dpdk->port_id;
@@ -762,18 +771,6 @@ static int dpdk_setup_eth_rx(const pktio_entry_t *pktio_entry,
 	rxconf = dev_info->default_rxconf;
 
 	rxconf.rx_drop_en = pkt_dpdk->opt.rx_drop_en;
-
-	rx_offloads = 0;
-	if (pktio_entry->s.config.pktin.bit.ipv4_chksum)
-		rx_offloads |= DEV_RX_OFFLOAD_IPV4_CKSUM;
-
-	if (pktio_entry->s.config.pktin.bit.udp_chksum)
-		rx_offloads |= DEV_RX_OFFLOAD_UDP_CKSUM;
-
-	if (pktio_entry->s.config.pktin.bit.tcp_chksum)
-		rx_offloads |= DEV_RX_OFFLOAD_TCP_CKSUM;
-
-	rxconf.offloads = rx_offloads;
 
 	for (i = 0; i < pktio_entry->s.num_in_queue; i++) {
 		ret = rte_eth_rx_queue_setup(port_id, i,


### PR DESCRIPTION
The NIC offload capabilities stored in rte_eth_dev_info.rx_offload_capa/
tx_offload_capa cannot be used per NIC queue. Fix this by doing offload
configurarion using rte_eth_dev_configure().

Signed-off-by: Matias Elo <matias.elo@nokia.com>