### PR TITLE
[PATCH v3] linux-dpdk: pktio: add configuration option for ethernet multicast receipt

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.8"
+config_file_version = "0.1.9"
 
 # System options
 system: {
@@ -53,6 +53,9 @@ pktio_dpdk: {
 	num_rx_desc = 128
 	num_tx_desc = 256
 	rx_drop_en = 0
+
+	# Enable receipt of Ethernet frames sent to any multicast group
+	multicast_en = 1
 
 	# Driver specific options (use PMD names from DPDK)
 	net_ixgbe: {


### PR DESCRIPTION
Add new configuration option 'pktio_dpdk.multicast_en' for selecting
whether multicast Ethernet frames should be received or dropped.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Shen Hanxiao <hanxiao.shen@nokia-sbell.com>


V2:
- Fixed config option comment (Petri)