### PR TITLE
[PATCH v2] linux-dpdk: fix out-of-tree build

### DIFF
--- a/platform/linux-dpdk/Makefile.inc
+++ b/platform/linux-dpdk/Makefile.inc
@@ -1,6 +1,6 @@
 AM_CFLAGS += $(DPDK_CFLAGS)
 AM_CXXFLAGS += $(DPDK_CFLAGS)
 
-LOG_COMPILER = $(top_srcdir)/platform/linux-dpdk/test/wrapper-script.sh
+LOG_COMPILER = $(top_builddir)/platform/linux-dpdk/test/wrapper-script.sh
 SH_LOG_COMPILER = $(LOG_COMPILER)
-dist_check_SCRIPTS = $(top_srcdir)/platform/linux-dpdk/test/wrapper-script.sh
+dist_check_SCRIPTS = $(top_builddir)/platform/linux-dpdk/test/wrapper-script.sh

--- a/platform/linux-dpdk/test/Makefile.am
+++ b/platform/linux-dpdk/test/Makefile.am
@@ -6,12 +6,14 @@ SUBDIRS =
 if test_vald
 TESTS = validation/api/pktio/pktio_run.sh
 
-SUBDIRS += validation/api/pktio
+test_SCRIPTS = $(dist_check_SCRIPTS)
+
+SUBDIRS += validation/api/pktio \
+	   example
 else
 #performance tests refer to pktio_env
 if test_perf
-SUBDIRS += validation/api/pktio \
-	   example
+SUBDIRS += validation/api/pktio
 endif
 endif
 
@@ -34,3 +36,23 @@ if test_installdir
 installcheck-local:
 	$(DESTDIR)/$(testdir)/run-test.sh $(TESTNAME)
 endif
+
+# If building out-of-tree, make check will not copy the scripts and data to the
+# $(builddir) assuming that all commands are run locally. However this prevents
+# running tests on a remote target using LOG_COMPILER.
+# So copy all script and data files explicitly here.
+all-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			if [ -e $(srcdir)/$$f ]; then \
+				mkdir -p $(builddir)/$$(dirname $$f); \
+				cp -f $(srcdir)/$$f $(builddir)/$$f; \
+			fi \
+		done \
+	fi
+clean-local:
+	if [ "x$(srcdir)" != "x$(builddir)" ]; then \
+		for f in $(dist_check_SCRIPTS); do \
+			rm -f $(builddir)/$$f; \
+		done \
+	fi


### PR DESCRIPTION
Previously, running 'make clean' in an out-of-tree build directory
incorrectly deleted wrapper-script.sh in the source directory.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reported-by: Carl Wallen <carl.wallen@nokia.com>