### PR TITLE
[PATCH v3] README.DPDK: add instructions for DPDK 20.11

### DIFF
--- a/platform/linux-dpdk/README
+++ b/platform/linux-dpdk/README
@@ -1,5 +1,5 @@
 Copyright (c) 2018-2019, Linaro Limited
-Copyright (c) 2019-2020, Nokia
+Copyright (c) 2019-2021, Nokia
 All rights reserved.
 
 SPDX-License-Identifier:        BSD-3-Clause
@@ -24,28 +24,26 @@ Prerequisites and considerations:
 - DPDK only works on a selected range of network cards. The list of known and
   supported devices can be found in the DPDK documentation:
       http://doc.dpdk.org/guides-19.11/nics/index.html
+      http://doc.dpdk.org/guides-20.11/nics/index.html
 
 
 2. Preparing DPDK
 =================================================
 
-Fetching the DPDK code:
-----------------------
-Right now odp-dpdk supports DPDK v19.11 (recommended version) and v18.11:
-    git clone http://dpdk.org/git/dpdk-stable --branch 19.11 --depth 1 ./<dpdk-dir>
-
-or
-
-    git clone http://dpdk.org/git/dpdk-stable --branch 18.11 --depth 1 ./<dpdk-dir>
-
-Compile DPDK:
-------------
 Please refer to http://dpdk.org/doc/guides/linux_gsg/build_dpdk.html for more
 details on how to build DPDK. Best effort is done to provide some help on DPDK
 cmds below for Ubuntu, where it has been compiled and tested.
 
 On Ubuntu install pcap development library:
     sudo apt-get install libpcap-dev
+
+Right now odp-dpdk supports DPDK v19.11 (recommended version) and
+v20.11. v18.11 may also work.
+
+Compile DPDK 19.11
+------------------
+Fetch the DPDK code:
+    git clone http://dpdk.org/git/dpdk-stable --branch 19.11 --depth 1 ./<dpdk-dir>
 
 This has to be done only once:
     cd <dpdk-dir>
@@ -74,6 +72,22 @@ STATIC libraries:
 
 This only ensures building DPDK, but traffic is not tested with this build yet.
 
+Compile DPDK 20.11
+------------------
+Fetch the DPDK code:
+    git clone http://dpdk.org/git/dpdk-stable --branch 20.11 --depth 1 ./<dpdk-dir>
+
+Prepare the build directory:
+    cd <dpdk-dir>
+    meson build
+    cd build
+
+Configure the location where DPDK will be installed:
+    meson configure -Dprefix=$(pwd)/../install
+
+Build and install DPDK:
+    ninja install
+
 
 3. Compile ODP-DPDK
 =================================================
@@ -91,6 +105,10 @@ SHARED libraries (requires building DPDK with -fPIC, see above):
 STATIC libraries (better performance):
     ./configure --with-dpdk-path=<dpdk-dir>/install --disable-shared
 
+With DPDK 20.11, instead of --with-dpdk-path option, set PKG_CONFIG_PATH:
+    PKG_CONFIG_PATH=<dpdk-dir>/install/lib/x86_64-linux-gnu/pkgconfig ./configure
+
+Once configure has completed successfully:
     make
 
 
@@ -278,8 +296,8 @@ Get the Intel Multi-Buffer Crypto library from
 https://github.com/intel/intel-ipsec-mb and follow the README from the repo on
 how to build the library.
 
-Building DPDK:
-
+Building DPDK 19.11
+-------------------
 Follow the instructions from "Compile DPDK" section and make sure to enable the
 necessary crypto PMDs:
 E.g.
@@ -295,6 +313,16 @@ sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_SNOW3G=).*,\1y,' .config
 AESNI_MULTI_BUFFER_LIB_PATH=/path-to/Intel-multi-buffer-crypto/ \
 	make install T=x86_64-native-linuxapp-gcc DESTDIR=./install EXTRA_CFLAGS="-fPIC"
 
+Building DPDK 20.11
+-------------------
+If libIPSec_MB has been installed outside the normal search paths,
+configure the compiler and linker options with
+
+meson configure -Dc_args=-I/path-to/Intel-multi-buffer-crypto/include \
+      -Dc_link_args=-L/path-to/Intel-multi-buffer-crypto/lib
+
+Runtime parameters
+------------------
 When running an ODP application, include the required crypto devices in
 ODP_PLATFORM_PARAMS environment variable.
 E.g. ODP_PLATFORM_PARAMS="--vdev crypto_aesni_mb --vdev crypto_null"


### PR DESCRIPTION
```
Add instructions for building DPDK 20.11, using meson and ninja. DPDK
19.11 is still the recommended version.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
v2:
- Add PKG_CONFIG_PATH instruction.
