### PR TITLE
[PATCH v2] linux-dpdk: packet_flags: fix implicit type conversion

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Ubuntu 20.04
         env:
+          CONF: "--enable-dpdk-shared"
           OS: ubuntu_20.04
         run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${{matrix.compiler}}"
                -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/build_${ARCH}.sh

--- a/platform/linux-dpdk/include/odp/api/plat/packet_flag_inlines.h
+++ b/platform/linux-dpdk/include/odp/api/plat/packet_flag_inlines.h
@@ -70,8 +70,7 @@ _ODP_INLINE int odp_packet_has_jumbo(odp_packet_t pkt)
 
 _ODP_INLINE int odp_packet_has_flow_hash(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint64_t, ol_flags) &
-			_odp_packet_inline.rss_flag;
+	return !!(_odp_pkt_get(pkt, uint64_t, ol_flags) & _odp_packet_inline.rss_flag);
 }
 
 _ODP_INLINE void odp_packet_has_flow_hash_clr(odp_packet_t pkt)

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -27,8 +27,11 @@ if [ -z "$ODP_LIB_NAME" ] ; then
 ODP_LIB_NAME=libodp-dpdk
 fi
 
+# Additional warning checks
+EXTRA_CHECKS="-Werror -Wall -Wextra -Wconversion -Wundef -Wpointer-arith -Wfloat-equal -Wpacked"
+
 CC="${CC:-${TARGET_ARCH}-gcc}"
-${CC} ${CFLAGS} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst_dynamic \
+${CC} ${CFLAGS} ${EXTRA_CHECKS} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst_dynamic \
 	`PKG_CONFIG_PATH=/opt/odp/lib/pkgconfig ${PKG_CONFIG} --cflags --libs ${ODP_LIB_NAME}` \
 	`${PKG_CONFIG} --cflags --libs libdpdk`
 


### PR DESCRIPTION
Fix warning (-Wconversion) caused by an implicit cast in `odp_packet_has_flow_hash()` return value. The return value could be altered due to an implicit `uint64_t` to `int` conversion.