### PR TITLE
[PATCH v2] linux-dpdk: ipsec: increase default crypto sessions to 4000

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -35,8 +35,7 @@
 #include <string.h>
 #include <math.h>
 
-/* default number supported by DPDK crypto */
-#define MAX_SESSIONS 2048
+#define MAX_SESSIONS 4000
 /*
  * Max size of per-thread session object cache. May be useful if sessions
  * are created and destroyed very frequently.


### PR DESCRIPTION
This change will make linux-dpdk default value to same as linux-generic
value of 4000

Signed-off-by: Vijay Ram Inavolu <vinavolu@marvell.com>