### PR TITLE
[PATCH v5] linux-dpdk: pool: implement external memory pool

### DIFF
--- a/platform/linux-dpdk/include/odp_pool_internal.h
+++ b/platform/linux-dpdk/include/odp_pool_internal.h
@@ -67,12 +67,16 @@ typedef struct ODP_ALIGNED_CACHE {
 
 	/* Everything under this mark is memset() to zero on pool create */
 	uint8_t			memset_mark;
-	uint8_t			type;
-	uint8_t			pool_ext;
-	char			name[ODP_POOL_NAME_LEN];
-	odp_pool_param_t	params;
 	struct rte_mempool	*rte_mempool;
 	uint32_t		seg_len;
+	uint32_t		hdr_size;
+	uint32_t		num;
+	uint32_t		num_populated;
+	uint8_t			type;
+	uint8_t			pool_ext;
+	odp_pool_param_t	params;
+	odp_pool_ext_param_t	ext_param;
+	char			name[ODP_POOL_NAME_LEN];
 
 } pool_t;
 

--- a/platform/linux-dpdk/odp_packet.c
+++ b/platform/linux-dpdk/odp_packet.c
@@ -2413,50 +2413,159 @@ int odp_packet_reass_partial_state(odp_packet_t pkt, odp_packet_t frags[],
 	return -ENOTSUP;
 }
 
-void *odp_packet_buf_head(odp_packet_buf_t pkt_buf ODP_UNUSED)
+static inline odp_packet_hdr_t *packet_buf_to_hdr(odp_packet_buf_t pkt_buf)
 {
-	return NULL;
+	return (odp_packet_hdr_t *)(uintptr_t)pkt_buf;
 }
 
-uint32_t odp_packet_buf_size(odp_packet_buf_t pkt_buf ODP_UNUSED)
+void *odp_packet_buf_head(odp_packet_buf_t pkt_buf)
 {
-	return 0;
+	odp_packet_hdr_t *pkt_hdr = packet_buf_to_hdr(pkt_buf);
+	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
+
+	if (odp_unlikely(pool->pool_ext == 0)) {
+		ODP_ERR("Not an external memory pool\n");
+		return NULL;
+	}
+
+	return (uint8_t *)pkt_hdr + pool->hdr_size;
 }
 
-uint32_t odp_packet_buf_data_offset(odp_packet_buf_t pkt_buf ODP_UNUSED)
+uint32_t odp_packet_buf_size(odp_packet_buf_t pkt_buf)
 {
-	return 0;
+	odp_packet_hdr_t *pkt_hdr = packet_buf_to_hdr(pkt_buf);
+	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
+
+	return pool->seg_len;
 }
 
-uint32_t odp_packet_buf_data_len(odp_packet_buf_t pkt_buf ODP_UNUSED)
+uint32_t odp_packet_buf_data_offset(odp_packet_buf_t pkt_buf)
 {
-	return 0;
+	void *data = odp_packet_seg_data(ODP_PACKET_INVALID,
+					 (odp_packet_seg_t)pkt_buf);
+	void *head = odp_packet_buf_head(pkt_buf);
+
+	return (uintptr_t)data - (uintptr_t)head;
 }
 
-void odp_packet_buf_data_set(odp_packet_buf_t pkt_buf ODP_UNUSED,
-			     uint32_t data_offset ODP_UNUSED,
-			     uint32_t data_len ODP_UNUSED)
+uint32_t odp_packet_buf_data_len(odp_packet_buf_t pkt_buf)
 {
+	return odp_packet_seg_data_len(ODP_PACKET_INVALID,
+				       (odp_packet_seg_t)pkt_buf);
 }
 
-odp_packet_buf_t odp_packet_buf_from_head(odp_pool_t pool_hdl ODP_UNUSED,
-					  void *head ODP_UNUSED)
+void odp_packet_buf_data_set(odp_packet_buf_t pkt_buf, uint32_t data_offset,
+			     uint32_t data_len)
 {
-	return ODP_PACKET_BUF_INVALID;
+	odp_packet_hdr_t *pkt_hdr = packet_buf_to_hdr(pkt_buf);
+
+	pkt_hdr->buf_hdr.mb.data_off = data_offset;
+	pkt_hdr->buf_hdr.mb.data_len = data_len;
 }
 
-uint32_t odp_packet_disassemble(odp_packet_t pkt ODP_UNUSED,
-				odp_packet_buf_t pkt_buf[] ODP_UNUSED,
-				uint32_t num ODP_UNUSED)
+odp_packet_buf_t odp_packet_buf_from_head(odp_pool_t pool_hdl, void *head)
 {
-	return 0;
+	pool_t *pool = pool_entry_from_hdl(pool_hdl);
+
+	if (odp_unlikely(pool->type != ODP_POOL_PACKET)) {
+		ODP_ERR("Not a packet pool\n");
+		return ODP_PACKET_BUF_INVALID;
+	}
+
+	if (odp_unlikely(pool->pool_ext == 0)) {
+		ODP_ERR("Not an external memory pool\n");
+		return ODP_PACKET_BUF_INVALID;
+	}
+
+	return (odp_packet_buf_t)((uintptr_t)head - pool->hdr_size);
 }
 
-odp_packet_t odp_packet_reassemble(odp_pool_t pool_hdl ODP_UNUSED,
-				   odp_packet_buf_t pkt_buf[] ODP_UNUSED,
-				   uint32_t num ODP_UNUSED)
+uint32_t odp_packet_disassemble(odp_packet_t pkt, odp_packet_buf_t pkt_buf[],
+				uint32_t num)
 {
-	return ODP_PACKET_INVALID;
+	uint32_t i;
+	odp_packet_seg_t seg;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
+	uint32_t num_segs = odp_packet_num_segs(pkt);
+
+	if (odp_unlikely(pool->type != ODP_POOL_PACKET)) {
+		ODP_ERR("Not a packet pool\n");
+		return 0;
+	}
+
+	if (odp_unlikely(pool->pool_ext == 0)) {
+		ODP_ERR("Not an external memory pool\n");
+		return 0;
+	}
+
+	if (odp_unlikely(num < num_segs)) {
+		ODP_ERR("Not enough buffer handles %u. Packet has %u segments.\n",
+			num, num_segs);
+		return 0;
+	}
+
+	seg = odp_packet_first_seg(pkt);
+
+	for (i = 0; i < num_segs; i++) {
+		pkt_buf[i] = (odp_packet_buf_t)(uintptr_t)seg;
+		seg = odp_packet_next_seg(pkt, seg);
+	}
+
+	return num_segs;
+}
+
+odp_packet_t odp_packet_reassemble(odp_pool_t pool_hdl,
+				   odp_packet_buf_t pkt_buf[], uint32_t num)
+{
+	uint32_t i, data_len;
+	odp_packet_hdr_t *cur_seg, *next_seg;
+	odp_packet_hdr_t *pkt_hdr = (odp_packet_hdr_t *)(uintptr_t)pkt_buf[0];
+	uint32_t headroom = odp_packet_buf_data_offset(pkt_buf[0]);
+
+	pool_t *pool = pool_entry_from_hdl(pool_hdl);
+
+	if (odp_unlikely(pool->type != ODP_POOL_PACKET)) {
+		ODP_ERR("Not a packet pool\n");
+		return ODP_PACKET_INVALID;
+	}
+
+	if (odp_unlikely(pool->pool_ext == 0)) {
+		ODP_ERR("Not an external memory pool\n");
+		return ODP_PACKET_INVALID;
+	}
+
+	if (odp_unlikely(num == 0)) {
+		ODP_ERR("Bad number of buffers: %u\n", num);
+		return ODP_PACKET_INVALID;
+	}
+
+	cur_seg = pkt_hdr;
+	data_len = 0;
+
+	for (i = 0; i < num; i++) {
+		struct rte_mbuf *mb;
+
+		next_seg = NULL;
+		if (i < num - 1)
+			next_seg = (odp_packet_hdr_t *)(uintptr_t)pkt_buf[i + 1];
+
+		data_len += cur_seg->buf_hdr.mb.data_len;
+		mb = (struct rte_mbuf *)(uintptr_t)cur_seg;
+		mb->next = (struct rte_mbuf *)next_seg;
+		cur_seg = next_seg;
+	}
+
+	pkt_hdr->buf_hdr.mb.nb_segs = num;
+	pkt_hdr->buf_hdr.mb.pkt_len = data_len;
+	pkt_hdr->buf_hdr.mb.data_off = headroom;
+
+	/* Reset metadata */
+	pkt_hdr->subtype = ODP_EVENT_PACKET_BASIC;
+	pkt_hdr->input = ODP_PKTIO_INVALID;
+	packet_parse_reset(pkt_hdr, 1);
+
+	return packet_handle(pkt_hdr);
 }
 
 void odp_packet_proto_stats_request(odp_packet_t pkt, odp_packet_proto_stats_opt_t *opt)

--- a/platform/linux-dpdk/odp_packet.c
+++ b/platform/linux-dpdk/odp_packet.c
@@ -140,8 +140,29 @@ static odp_packet_t packet_alloc(pool_t *pool, uint32_t len)
 
 		ret = rte_pktmbuf_alloc_bulk(pool->rte_mempool, mbufs, num_seg);
 		if (odp_unlikely(ret)) {
-			_odp_errno = ENOMEM;
-			return ODP_PACKET_INVALID;
+			/*
+			 * rte_pktmbuf_alloc_bulk() fails when allocating the
+			 * last buffers from the pool, if some of them, but not
+			 * all, are in the cache.
+			 *
+			 * Try to allocate the buffers one by one.
+			 */
+			for (i = 0; i < num_seg; i++) {
+				mbufs[i] = rte_pktmbuf_alloc(pool->rte_mempool);
+				if (!mbufs[i]) {
+					/*
+					 * Failed to allocate the number of
+					 * buffers that we wanted. Free the ones
+					 * we managed to allocate, if any, and
+					 * return error.
+					 */
+					while (i > 0)
+						rte_pktmbuf_free(mbufs[--i]);
+
+					_odp_errno = ENOMEM;
+					return ODP_PACKET_INVALID;
+				}
+			}
 		}
 
 		head = mbufs[0];

--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -33,8 +33,9 @@
 
 #include <rte_config.h>
 #include <rte_errno.h>
-#include <rte_version.h>
 #include <rte_mempool.h>
+#include <rte_mbuf_pool_ops.h>
+#include <rte_malloc.h>
 /* ppc64 rte_memcpy.h (included through rte_mempool.h) may define vector */
 #if defined(__PPC64__) && defined(vector)
 	#undef vector
@@ -319,7 +320,19 @@ odp_dpdk_mbuf_ctor(struct rte_mempool *mp,
 
 	RTE_ASSERT(mp->elt_size >= sizeof(struct rte_mbuf));
 
-	memset(mb, 0, mp->elt_size);
+	if (mb_ctor_arg->pool->pool_ext) {
+		odp_pool_ext_param_t *p = &mb_ctor_arg->pool->ext_param;
+		uint32_t app_hdr_offset =
+			sizeof(odp_packet_hdr_t) + p->pkt.uarea_size;
+		uint32_t app_hdr_size = p->pkt.app_header_size;
+		uint32_t buf_size = p->pkt.buf_size;
+
+		memset(mb, 0, app_hdr_offset);
+		memset((uint8_t *)mb + app_hdr_offset + app_hdr_size, 0,
+		       buf_size - app_hdr_offset - app_hdr_size);
+	} else {
+		memset(mb, 0, mp->elt_size);
+	}
 
 	/* Start of buffer is just after the ODP type specific header
 	 * which contains in the very beginning the rte_mbuf struct */
@@ -892,8 +905,16 @@ int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 	if (pool == NULL || info == NULL)
 		return -1;
 
+	memset(info, 0, sizeof(odp_pool_info_t));
+
 	info->name = pool->name;
-	info->params = pool->params;
+
+	if (pool->pool_ext) {
+		info->pool_ext = 1;
+		info->pool_ext_param = pool->ext_param;
+	} else {
+		info->params = pool->params;
+	}
 
 	if (pool->type == ODP_POOL_PACKET)
 		info->pkt.max_num = pool->rte_mempool->size;
@@ -993,36 +1014,345 @@ int odp_pool_stats_reset(odp_pool_t pool_hdl ODP_UNUSED)
 	return 0;
 }
 
-int odp_pool_ext_capability(odp_pool_type_t type, odp_pool_ext_capability_t *capa)
+/*
+ * No actual head pointer alignment requirement. Anyway, require even byte
+ * address.
+ */
+#define EXT_MIN_HEAD_ALIGN 2
+
+#define EXT_UAREA_SIZE 32
+
+/*
+ * Round up the space we reserve for objhdr up to cache line size. The rte_mbuf
+ * that comes after this must be cache line aligned.
+ */
+#define SIZEOF_OBJHDR ROUNDUP_CACHE_LINE(sizeof(struct rte_mempool_objhdr))
+
+int odp_pool_ext_capability(odp_pool_type_t type,
+			    odp_pool_ext_capability_t *capa)
 {
+	odp_pool_stats_opt_t supported_stats;
+
 	if (type != ODP_POOL_PACKET)
 		return -1;
+
+	supported_stats.all = 0;
 
 	memset(capa, 0, sizeof(odp_pool_ext_capability_t));
 
 	capa->type = type;
-	capa->max_pools = 0;
+	capa->max_pools = ODP_CONFIG_POOLS - 1;
+	capa->min_cache_size = 0;
+	capa->max_cache_size = RTE_MEMPOOL_CACHE_MAX_SIZE;
+	capa->stats.all = supported_stats.all;
+
+	capa->pkt.max_num_buf = _odp_pool_glb->config.pkt_max_num;
+	capa->pkt.max_buf_size = MAX_SIZE;
+	capa->pkt.odp_header_size =
+		SIZEOF_OBJHDR + sizeof(odp_packet_hdr_t) + EXT_UAREA_SIZE;
+	capa->pkt.odp_trailer_size = 0;
+	capa->pkt.min_mem_align = ODP_CACHE_LINE_SIZE;
+	capa->pkt.min_buf_align = ODP_CACHE_LINE_SIZE;
+	capa->pkt.min_head_align = EXT_MIN_HEAD_ALIGN;
+	capa->pkt.buf_size_aligned = 0;
+	capa->pkt.max_headroom = CONFIG_PACKET_HEADROOM;
+	capa->pkt.max_headroom_size = CONFIG_PACKET_HEADROOM;
+	capa->pkt.max_segs_per_pkt = PKT_MAX_SEGS;
+	capa->pkt.max_uarea_size = EXT_UAREA_SIZE;
 
 	return 0;
 }
 
-void odp_pool_ext_param_init(odp_pool_type_t type ODP_UNUSED,
-			     odp_pool_ext_param_t *param)
+void odp_pool_ext_param_init(odp_pool_type_t type, odp_pool_ext_param_t *param)
 {
+	uint32_t default_cache_size = RTE_MEMPOOL_CACHE_MAX_SIZE;
+
 	memset(param, 0, sizeof(odp_pool_ext_param_t));
+
+	if (type != ODP_POOL_PACKET)
+		return;
+
+	param->type = ODP_POOL_PACKET;
+	param->cache_size = default_cache_size;
+	param->pkt.headroom = CONFIG_PACKET_HEADROOM;
 }
 
-odp_pool_t odp_pool_ext_create(const char *name ODP_UNUSED,
-			       const odp_pool_ext_param_t *param ODP_UNUSED)
+static int check_pool_ext_param(const odp_pool_ext_param_t *param)
 {
+	odp_pool_ext_capability_t capa;
+	uint32_t head_offset = SIZEOF_OBJHDR + sizeof(odp_packet_hdr_t) +
+			       param->pkt.uarea_size +
+			       param->pkt.app_header_size;
+
+	if (param->type != ODP_POOL_PACKET) {
+		ODP_ERR("Pool type not supported\n");
+		return -1;
+	}
+
+	if (odp_pool_ext_capability(param->type, &capa)) {
+		ODP_ERR("Capa failed\n");
+		return -1;
+	}
+
+	if (param->cache_size > capa.max_cache_size) {
+		ODP_ERR("Too large cache size %u\n", param->cache_size);
+		return -1;
+	}
+
+	if (param->stats.all != capa.stats.all) {
+		ODP_ERR("Pool statistics not supported\n");
+		return -1;
+	}
+
+	if (param->pkt.num_buf > capa.pkt.max_num_buf) {
+		ODP_ERR("Too many packet buffers\n");
+		return -1;
+	}
+
+	if (param->pkt.buf_size > capa.pkt.max_buf_size) {
+		ODP_ERR("Too large packet buffer size %u\n",
+			param->pkt.buf_size);
+		return -1;
+	}
+
+	if (param->pkt.uarea_size > capa.pkt.max_uarea_size) {
+		ODP_ERR("Too large user area size %u\n", param->pkt.uarea_size);
+		return -1;
+	}
+
+	if (param->pkt.headroom > capa.pkt.max_headroom) {
+		ODP_ERR("Too large headroom size\n");
+		return -1;
+	}
+
+	if (head_offset % capa.pkt.min_head_align) {
+		ODP_ERR("Head pointer not %u byte aligned\n",
+			capa.pkt.min_head_align);
+		return -1;
+	}
+
+	return 0;
+}
+
+odp_pool_t odp_pool_ext_create(const char *name,
+			       const odp_pool_ext_param_t *params)
+{
+	odp_pool_t pool_hdl = ODP_POOL_INVALID;
+	unsigned int i, cache_size;
+	size_t hdr_size, priv_size;
+	pool_t *pool;
+	uint32_t buf_size, blk_size;
+	char pool_name[ODP_POOL_NAME_LEN];
+	char rte_name[RTE_MEMPOOL_NAMESIZE];
+
+	if (check_pool_ext_param(params))
+		return ODP_POOL_INVALID;
+
+	if (name == NULL) {
+		pool_name[0] = 0;
+	} else {
+		strncpy(pool_name, name, ODP_POOL_NAME_LEN - 1);
+		pool_name[ODP_POOL_NAME_LEN - 1] = 0;
+	}
+
+	/* Find an unused buffer pool slot and initialize it as requested */
+	for (i = 0; i < ODP_CONFIG_POOLS; i++) {
+		uint32_t num;
+		struct rte_mempool *mp;
+
+		pool = pool_entry(i);
+
+		LOCK(&pool->lock);
+		if (pool->rte_mempool != NULL) {
+			UNLOCK(&pool->lock);
+			continue;
+		}
+
+		memset(&pool->memset_mark, 0,
+		       sizeof(pool_t) - offsetof(pool_t, memset_mark));
+
+		hdr_size = sizeof(odp_packet_hdr_t) + params->pkt.uarea_size +
+			   params->pkt.app_header_size;
+		priv_size = hdr_size - sizeof(struct rte_mbuf);
+		buf_size = params->pkt.buf_size;
+		blk_size = buf_size - SIZEOF_OBJHDR - hdr_size;
+		num = params->pkt.num_buf;
+
+		ODP_DBG("type: packet, name: %s, num: %u, len: %u, blk_size: %u, "
+			"uarea_size: %d, hdr_size: %zu\n",
+			pool_name, num, buf_size, blk_size,
+			params->pkt.uarea_size, hdr_size);
+
+		cache_size = params->cache_size;
+		cache_size = calc_cache_size(num, cache_size);
+
+		format_pool_name(pool_name, rte_name);
+
+		mp = rte_mempool_create_empty(
+			rte_name, num, blk_size, cache_size,
+			sizeof(struct rte_pktmbuf_pool_private),
+			rte_socket_id(), 0);
+
+		if (mp == NULL) {
+			ODP_ERR("Failed to create empty DPDK packet pool\n");
+			goto error;
+		}
+
+		if (rte_mempool_set_ops_byname(mp, rte_mbuf_best_mempool_ops(),
+					       NULL)) {
+			ODP_ERR("Failed setting mempool operations\n");
+			goto error;
+		}
+
+		struct rte_pktmbuf_pool_private mbp_priv = {
+			.mbuf_data_room_size = blk_size,
+			.mbuf_priv_size = priv_size,
+		};
+
+		rte_pktmbuf_pool_init(mp, &mbp_priv);
+
+		/*
+		 * Would like to call rte_mempool_ops_alloc(), but it doesn't
+		 * appear to be included in the libraries provided by Ubuntu or
+		 * Fedora.
+		 */
+		if (rte_mempool_get_ops(mp->ops_index)->alloc(mp)) {
+			ODP_ERR("Mempool alloc operation failed\n");
+			goto error;
+		}
+
+		pool->ext_param = *params;
+		pool->hdr_size = hdr_size;
+		pool->num = num;
+		pool->num_populated = 0;
+		pool->params.pkt.uarea_size = params->pkt.uarea_size;
+		pool->params.type = params->type;
+		pool->pool_ext = 1;
+		pool->rte_mempool = mp;
+		pool->seg_len = blk_size;
+		pool->type = params->type;
+		strcpy(pool->name, pool_name);
+
+		ODP_DBG("Header/element/trailer size: %u/%u/%u, "
+			"total pool size: %lu\n",
+			mp->header_size, mp->elt_size, mp->trailer_size,
+			(unsigned long)((mp->header_size + mp->elt_size +
+					 mp->trailer_size) *
+					num));
+		UNLOCK(&pool->lock);
+		pool_hdl = pool->pool_hdl;
+		break;
+	}
+
+	return pool_hdl;
+
+error:
+	UNLOCK(&pool->lock);
 	return ODP_POOL_INVALID;
 }
 
-int odp_pool_ext_populate(odp_pool_t pool_hdl ODP_UNUSED,
-			  void *buf[] ODP_UNUSED,
-			  uint32_t buf_size ODP_UNUSED,
-			  uint32_t num ODP_UNUSED,
-			  uint32_t flags ODP_UNUSED)
+int odp_pool_ext_populate(odp_pool_t pool_hdl, void *buf[], uint32_t buf_size,
+			  uint32_t num, uint32_t flags)
 {
-	return -1;
+	pool_t *pool;
+	uint32_t num_populated;
+
+	if (pool_hdl == ODP_POOL_INVALID) {
+		ODP_ERR("Bad pool handle\n");
+		return -1;
+	}
+
+	pool = pool_entry_from_hdl(pool_hdl);
+
+	if (pool->type != ODP_POOL_PACKET || pool->pool_ext == 0) {
+		ODP_ERR("Bad pool type\n");
+		return -1;
+	}
+
+	if (buf_size != pool->ext_param.pkt.buf_size) {
+		ODP_ERR("Bad buffer size\n");
+		return -1;
+	}
+
+	num_populated = pool->num_populated;
+
+	if (num_populated + num > pool->num) {
+		ODP_ERR("Trying to over populate the pool\n");
+		return -1;
+	}
+
+	if ((num_populated + num == pool->num) &&
+	    !(flags & ODP_POOL_POPULATE_DONE)) {
+		ODP_ERR("Missing ODP_POOL_POPULATE_DONE flag\n");
+		return -1;
+	}
+
+	if ((num_populated + num < pool->num) && flags) {
+		ODP_ERR("Unexpected flags: 0x%x\n", flags);
+		return -1;
+	}
+
+	struct rte_mempool *mp = pool->rte_mempool;
+
+	for (uint32_t i = 0; i < num; i++) {
+		struct rte_mempool_objhdr *hdr;
+		struct rte_mempool_memhdr *memhdr;
+		struct rte_mbuf *mb =
+			(struct rte_mbuf *)((uintptr_t)buf[i] + SIZEOF_OBJHDR);
+		struct odp_pool_ext_param_t *params = &pool->ext_param;
+		struct mbuf_ctor_arg mb_ctor_arg;
+
+		/*
+		 * rte_mbuf must be cache line aligned, so that is our
+		 * requirement also for buffers.
+		 */
+		if ((uintptr_t)buf[i] & (ODP_CACHE_LINE_SIZE - 1)) {
+			ODP_ERR("Buffer address (%p) does not meet alignment requirements\n",
+				buf[i]);
+			return -1;
+		}
+
+		if (rte_mempool_ops_enqueue_bulk(mp, (void *const *)&mb, 1) < 0) {
+			ODP_ERR("Failed to enqueue buffer to rte_mempool\n");
+			return -1;
+		}
+
+		/*
+		 * Since we don't know anything about the caller's memory areas,
+		 * or even the page size, make a memhdr for each buffer.
+		 */
+		memhdr = rte_zmalloc(NULL, sizeof(*memhdr), 0);
+
+		if (!memhdr) {
+			ODP_ERR("Failed to allocate rte_mempool_memhdr\n");
+			return -1;
+		}
+
+		memhdr->mp = mp;
+		memhdr->addr = mb;
+		memhdr->iova = rte_mem_virt2iova(mb);
+		memhdr->len = buf_size;
+		STAILQ_INSERT_TAIL(&mp->mem_list, memhdr, next);
+		mp->nb_mem_chunks++;
+
+		hdr = RTE_PTR_SUB(mb, sizeof(*hdr));
+		hdr->mp = mp;
+		hdr->iova = rte_mem_virt2iova(mb);
+		STAILQ_INSERT_TAIL(&mp->elt_list, hdr, next);
+		mp->populated_size++;
+
+		mb_ctor_arg.pkt_uarea_size = params->pkt.uarea_size;
+		mb_ctor_arg.seg_buf_offset = sizeof(odp_packet_hdr_t) +
+					     params->pkt.uarea_size +
+					     params->pkt.app_header_size;
+		mb_ctor_arg.seg_buf_size = pool->seg_len;
+		mb_ctor_arg.type = params->type;
+		mb_ctor_arg.event_type = pool->type;
+		mb_ctor_arg.pool = pool;
+		odp_dpdk_mbuf_ctor(mp, (void *)&mb_ctor_arg, (void *)mb,
+				   mp->populated_size);
+		pool->num_populated++;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Implementation of external memory pool and packet disassemble and reassemble API.

v1:
- Includes ODP v1.31.0.0 merge draft by Matias.
- The only implementation difference to the earlier PR #139, which is now closed, is that application header is now correctly preserved in packet allocation.

v2:
- Rebase.
- Fix according to comments from @MatiasElo.

v3:
- Rebase.
- Add obj headers and mem headers.

v4:
- Check rte_mempool_ops_enqueue_bulk() and rte_zmalloc() return values.

v5:
- Align rte_mbuf to cache line.
- Check that populated buffers are aligned.
