### PR TITLE
[PATCH v8] linux-dpdk: pktio: add pci ports using config file

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.13"
+config_file_version = "0.1.14"
 
 # System options
 system: {
@@ -45,6 +45,19 @@ dpdk: {
 	# should reserve all shared resources and configure the system before
 	# forking child processes for the best success probability.
 	process_mode_memory_mb = 512
+
+	# PCI devices configuration.
+	#
+	# Specify them as lists of strings of format.
+	# "[domain:]bus:devid.func[,devargs]", where devargs are
+	# optional arguments in the "key1=value1,key2=value2,..." form.
+	# Either whitelist or blacklist should be defined but not both.
+	#
+	# List of PCI devices that should be used.
+	pci_whitelist = []
+
+	# List of PCI devices that should not be used.
+	pci_blacklist = []
 }
 
 # Pool options

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [13])
+m4_define([_odp_config_version_minor], [14])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.13"
+config_file_version = "0.1.14"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.13"
+config_file_version = "0.1.14"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -22,6 +22,8 @@ int _odp_libconfig_term_global(void);
 
 int _odp_libconfig_lookup_int(const char *path, int *value);
 int _odp_libconfig_lookup_array(const char *path, int value[], int max_num);
+int _odp_libconfig_lookup_array_str(const char *path, char **value,
+				    int max_count, unsigned int max_str);
 
 int _odp_libconfig_lookup_ext_int(const char *base_path,
 				  const char *local_path,


### PR DESCRIPTION
Implementation to support pci ports addition using the odp config file
for linux dpdk

Signed-off-by: Vijay Ram Inavolu <vinavolu@marvell.com>