### PR TITLE
[PATCH v3] linux-dpdk: timer: add new implementation using alt dpdk timer

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -268,6 +268,17 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
 
+  Run_alternate_timer:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo docker run -i -v `pwd`:/odp --privileged --shm-size 8g -e CC="${CC}" -e ARCH="${ARCH}"
+               -e ODP_CONFIG_FILE=/odp/platform/linux-dpdk/test/alternate-timer.conf
+               -e CONF="${CONF}" $CONTAINER_NAMESPACE/odp-ci-${OS}-${ARCH} /odp/scripts/ci/check.sh
+      - name: Failure log
+        if: ${{ failure() }}
+        run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
+
   Run_dpdk-20_11:
     runs-on: ubuntu-18.04
     env:

--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -191,6 +191,9 @@ timer: {
 	# a higher resolution than this, the polling rate is increased
 	# accordingly.
 	inline_poll_interval_nsec = 500000
+
+	# Use experimental DPDK alternate timer API based implementation
+	alternate = 0
 }
 
 ipsec: {

--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -138,6 +138,7 @@ noinst_HEADERS = \
 		  ${top_srcdir}/platform/linux-generic/include/odp_sorted_list_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_sysinfo_internal.h \
 		  include/odp_shm_internal.h \
+		  include/odp_thread_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_timer_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_timer_wheel_internal.h \
 		  ${top_srcdir}/platform/linux-generic/include/odp_traffic_mngr_internal.h \

--- a/platform/linux-dpdk/include/odp/api/plat/byteorder_inlines_api.h
+++ b/platform/linux-dpdk/include/odp/api/plat/byteorder_inlines_api.h
@@ -1,1 +1,0 @@
-../../../../../linux-generic/include/odp/api/plat/byteorder_inlines_api.h

--- a/platform/linux-dpdk/include/odp/api/plat/pktio_inlines_api.h
+++ b/platform/linux-dpdk/include/odp/api/plat/pktio_inlines_api.h
@@ -1,1 +1,0 @@
-../../../../../linux-generic/include/odp/api/plat/pktio_inlines_api.h

--- a/platform/linux-dpdk/include/odp/api/plat/thread_inlines_api.h
+++ b/platform/linux-dpdk/include/odp/api/plat/thread_inlines_api.h
@@ -1,1 +1,0 @@
-../../../../../linux-generic/include/odp/api/plat/thread_inlines_api.h

--- a/platform/linux-dpdk/include/odp/api/plat/ticketlock_inlines_api.h
+++ b/platform/linux-dpdk/include/odp/api/plat/ticketlock_inlines_api.h
@@ -1,1 +1,0 @@
-../../../../../linux-generic/include/odp/api/plat/ticketlock_inlines_api.h

--- a/platform/linux-dpdk/include/odp_thread_internal.h
+++ b/platform/linux-dpdk/include/odp_thread_internal.h
@@ -23,6 +23,13 @@ extern "C" {
  */
 int _odp_thread_cpu_ids(unsigned int cpu_ids[], int max_num);
 
+/**
+ * Read current epoch value of thread mask all
+ *
+ * @return Thread mask all epoch value
+ */
+uint64_t _odp_thread_thrmask_epoch(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-dpdk/include/odp_thread_internal.h
+++ b/platform/linux-dpdk/include/odp_thread_internal.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_THREAD_INTERNAL_H_
+#define ODP_THREAD_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+ * Read CPU IDs of active ODP threads
+ *
+ * @param[out] cpu_ids      CPU ID array
+ * @param      max_num      Maximum number of CPU IDs to write
+ *
+ * @return Number of CPU IDs written to the output array
+ */
+int _odp_thread_cpu_ids(unsigned int cpu_ids[], int max_num);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/platform/linux-dpdk/odp_thread.c
+++ b/platform/linux-dpdk/odp_thread.c
@@ -8,6 +8,7 @@
 #include <odp_posix_extensions.h>
 
 #include <sched.h>
+#include <odp/api/atomic.h>
 #include <odp/api/thread.h>
 #include <odp/api/thrmask.h>
 #include <odp/api/spinlock.h>
@@ -18,6 +19,7 @@
 #include <odp/api/align.h>
 #include <odp/api/cpu.h>
 #include <odp_schedule_if.h>
+#include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/plat/thread_inlines.h>
 #include <odp_thread_internal.h>
 #include <odp_libconfig_internal.h>
@@ -37,7 +39,7 @@ typedef struct {
 		odp_thrmask_t  worker;
 		odp_thrmask_t  control;
 	};
-
+	odp_atomic_u64_t thrmask_all_epoch;
 	uint32_t       num;
 	uint32_t       num_worker;
 	uint32_t       num_control;
@@ -88,6 +90,7 @@ int _odp_thread_init_global(void)
 	thread_globals->shm = shm;
 
 	odp_spinlock_init(&thread_globals->lock);
+	odp_atomic_init_u64(&thread_globals->thrmask_all_epoch, 0);
 	thread_globals->num_max = num_max;
 	ODP_PRINT("System config:\n");
 	ODP_PRINT("  system.thread_count_max: %d\n\n", num_max);
@@ -111,6 +114,11 @@ int _odp_thread_term_global(void)
 		ODP_ERR("shm free failed for odp_thread_globals");
 
 	return ret;
+}
+
+uint64_t _odp_thread_thrmask_epoch(void)
+{
+	return odp_atomic_load_u64(&thread_globals->thrmask_all_epoch);
 }
 
 int _odp_thread_cpu_ids(unsigned int cpu_ids[], int max_num)
@@ -138,6 +146,7 @@ static int alloc_id(odp_thread_type_t type)
 	for (thr = 0; thr < (int)thread_globals->num_max; thr++) {
 		if (odp_thrmask_isset(all, thr) == 0) {
 			odp_thrmask_set(all, thr);
+			odp_atomic_inc_u64(&thread_globals->thrmask_all_epoch);
 
 			if (type == ODP_THREAD_WORKER) {
 				odp_thrmask_set(&thread_globals->worker, thr);
@@ -166,6 +175,7 @@ static int free_id(int thr)
 		return -1;
 
 	odp_thrmask_clr(all, thr);
+	odp_atomic_inc_u64(&thread_globals->thrmask_all_epoch);
 
 	if (thread_globals->thr[thr].type == ODP_THREAD_WORKER) {
 		odp_thrmask_clr(&thread_globals->worker, thr);

--- a/platform/linux-dpdk/odp_thread.c
+++ b/platform/linux-dpdk/odp_thread.c
@@ -19,6 +19,7 @@
 #include <odp/api/cpu.h>
 #include <odp_schedule_if.h>
 #include <odp/api/plat/thread_inlines.h>
+#include <odp_thread_internal.h>
 #include <odp_libconfig_internal.h>
 
 #include <rte_config.h>
@@ -110,6 +111,20 @@ int _odp_thread_term_global(void)
 		ODP_ERR("shm free failed for odp_thread_globals");
 
 	return ret;
+}
+
+int _odp_thread_cpu_ids(unsigned int cpu_ids[], int max_num)
+{
+	odp_thrmask_t *all = &thread_globals->all;
+	int num_cpus = 0;
+	uint32_t thr;
+
+	for (thr = 0; num_cpus < max_num && thr < thread_globals->num_max; thr++) {
+		if (odp_thrmask_isset(all, thr))
+			cpu_ids[num_cpus++] = thread_globals->thr[thr].cpu;
+	}
+
+	return num_cpus;
 }
 
 static int alloc_id(odp_thread_type_t type)

--- a/platform/linux-dpdk/test/alternate-timer.conf
+++ b/platform/linux-dpdk/test/alternate-timer.conf
@@ -1,0 +1,8 @@
+# Mandatory fields
+odp_implementation = "linux-dpdk"
+config_file_version = "0.1.14"
+
+timer: {
+	# Enable alternate DPDK timer implementation
+	alternate = 1
+}


### PR DESCRIPTION
Add new timer implementation using DPDK alternate timer API. The main
difference compared to the standard implementation is that threads can also
process timers set by any other thread. The alternate timer implementation
can be enabled with 'timer.alternate' configuration file option.