### PR TITLE
[PATCH v2] linux-dpdk: crypto: fix disabling of AES-CMAC with aesni-mb driver

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1216,6 +1216,13 @@ check_auth:
 		if (cap->op == RTE_CRYPTO_OP_TYPE_UNDEFINED)
 			continue;
 
+		/* As a bug workaround, we do not use AES_CMAC with
+		 * the aesni-mb crypto driver.
+		 */
+		if (auth_xform->auth.algo == RTE_CRYPTO_AUTH_AES_CMAC &&
+		    is_dev_aesni_mb(&dev_info))
+			continue;
+
 		/* As a bug workaround, we do not use AES_XCBC_MAC with
 		 * the aesni-mb crypto driver.
 		 */


### PR DESCRIPTION
AES-CMAC is not included in crypto capabilities when found in aesni-mb
but it may still be included because some other crypto device supports it.
If aesni-mb device and another device that does support AES-CMAC are
present at the same time, then the aesni-mb device may still get selected
for a session that uses AES-CMAC.

Fix device selection in session creation by excluding AES-CMAC sessions
from the aesni-mb device.

Fixes: cf4d3329d4a9b53663ee27a904ee88f2cd3f50d8

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>