### PR TITLE
[PATCH v1] linux-dpdk: increment library version number to 1.31.0.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.5])
 m4_define([odpapi_generation_version], [1])
 m4_define([odpapi_major_version], [31])
 m4_define([odpapi_minor_version], [0])
-m4_define([odpapi_point_version], [0])
+m4_define([odpapi_point_version], [1])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])
 AC_INIT([OpenDataPlane],[odpapi_version],[odp@lists.opendataplane.org])


### PR DESCRIPTION
Increment implementation version number to reflect the following changes:

- Added implementation for the external memory pool API and related
  functions
- Added implementation for the new packet disassemble and reassemble
  functions, and related packet buffer accessor functions
- Added support for blacklisting/whitelisting PCI devices in config file

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Petri Savolainen <petri.savolainen@nokia.com>