### PR TITLE
[PATCH v3] linux-dpdk: align: use RTE_CACHE_LINE_SIZE as ODP_CACHE_LINE_SIZE

### DIFF
--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -240,6 +240,7 @@ endif
 if ARCH_IS_ARM
 __LIB__libodp_dpdk_la_SOURCES += arch/default/odp_atomic.c \
 				 arch/default/odp_cpu_cycles.c \
+				 arch/default/odp_global_time.c \
 				 arch/default/odp_hash_crc32.c \
 				 arch/arm/odp_sysinfo_parse.c
 odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu_time.h \

--- a/platform/linux-dpdk/arch
+++ b/platform/linux-dpdk/arch
@@ -1,1 +1,0 @@
-../linux-generic/arch/

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/atomic.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/atomic.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/atomic.h

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/atomic_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/atomic_inlines.h

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/aarch64/odp/api/abi/cpu.h
+/* Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/cpu_inlines.h

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu_time.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/cpu_time.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/cpu_time.h

--- a/platform/linux-dpdk/arch/aarch64/odp/api/abi/hash_crc32.h
+++ b/platform/linux-dpdk/arch/aarch64/odp/api/abi/hash_crc32.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/aarch64/odp/api/abi/hash_crc32.h

--- a/platform/linux-dpdk/arch/aarch64/odp_atomic.c
+++ b/platform/linux-dpdk/arch/aarch64/odp_atomic.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_atomic.c

--- a/platform/linux-dpdk/arch/aarch64/odp_atomic.h
+++ b/platform/linux-dpdk/arch/aarch64/odp_atomic.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_atomic.h

--- a/platform/linux-dpdk/arch/aarch64/odp_cpu.h
+++ b/platform/linux-dpdk/arch/aarch64/odp_cpu.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_cpu.h

--- a/platform/linux-dpdk/arch/aarch64/odp_cpu_idling.h
+++ b/platform/linux-dpdk/arch/aarch64/odp_cpu_idling.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_cpu_idling.h

--- a/platform/linux-dpdk/arch/aarch64/odp_global_time.c
+++ b/platform/linux-dpdk/arch/aarch64/odp_global_time.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_global_time.c

--- a/platform/linux-dpdk/arch/aarch64/odp_llsc.h
+++ b/platform/linux-dpdk/arch/aarch64/odp_llsc.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_llsc.h

--- a/platform/linux-dpdk/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/aarch64/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/aarch64/odp_sysinfo_parse.c

--- a/platform/linux-dpdk/arch/arm/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/arm/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/arm/odp/api/abi/cpu.h
+/* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/arm/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/arm/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/arm/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/arm/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-dpdk/arch/arm/odp/api/abi/cpu_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/arm/odp/api/abi/cpu_inlines.h

--- a/platform/linux-dpdk/arch/arm/odp_atomic.h
+++ b/platform/linux-dpdk/arch/arm/odp_atomic.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/arm/odp_atomic.h

--- a/platform/linux-dpdk/arch/arm/odp_cpu.h
+++ b/platform/linux-dpdk/arch/arm/odp_cpu.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/arm/odp_cpu.h

--- a/platform/linux-dpdk/arch/arm/odp_cpu_idling.h
+++ b/platform/linux-dpdk/arch/arm/odp_cpu_idling.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/arm/odp_cpu_idling.h

--- a/platform/linux-dpdk/arch/arm/odp_llsc.h
+++ b/platform/linux-dpdk/arch/arm/odp_llsc.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/arm/odp_llsc.h

--- a/platform/linux-dpdk/arch/arm/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/arm/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/arm/odp_sysinfo_parse.c

--- a/platform/linux-dpdk/arch/default/odp/api/abi/atomic_generic.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/atomic_generic.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/atomic_generic.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/atomic_inlines.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/atomic_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/atomic_inlines.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/default/odp/api/abi/cpu.h
+/* Copyright (c) 2018-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/default/odp/api/abi/cpu_generic.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/cpu_generic.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/cpu_generic.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/cpu_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/cpu_inlines.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/cpu_time.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/cpu_time.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/cpu_time.h

--- a/platform/linux-dpdk/arch/default/odp/api/abi/hash_crc32.h
+++ b/platform/linux-dpdk/arch/default/odp/api/abi/hash_crc32.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/default/odp/api/abi/hash_crc32.h

--- a/platform/linux-dpdk/arch/default/odp_atomic.c
+++ b/platform/linux-dpdk/arch/default/odp_atomic.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_atomic.c

--- a/platform/linux-dpdk/arch/default/odp_atomic.h
+++ b/platform/linux-dpdk/arch/default/odp_atomic.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_atomic.h

--- a/platform/linux-dpdk/arch/default/odp_cpu.h
+++ b/platform/linux-dpdk/arch/default/odp_cpu.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_cpu.h

--- a/platform/linux-dpdk/arch/default/odp_cpu_cycles.c
+++ b/platform/linux-dpdk/arch/default/odp_cpu_cycles.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_cpu_cycles.c

--- a/platform/linux-dpdk/arch/default/odp_cpu_idling.h
+++ b/platform/linux-dpdk/arch/default/odp_cpu_idling.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_cpu_idling.h

--- a/platform/linux-dpdk/arch/default/odp_global_time.c
+++ b/platform/linux-dpdk/arch/default/odp_global_time.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_global_time.c

--- a/platform/linux-dpdk/arch/default/odp_hash_crc32.c
+++ b/platform/linux-dpdk/arch/default/odp_hash_crc32.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_hash_crc32.c

--- a/platform/linux-dpdk/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/default/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/default/odp_sysinfo_parse.c

--- a/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/mips64/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/mips64/odp/api/abi/cpu.h
+/* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-dpdk/arch/mips64/odp/api/abi/cpu_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/mips64/odp/api/abi/cpu_inlines.h

--- a/platform/linux-dpdk/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/mips64/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/mips64/odp_sysinfo_parse.c

--- a/platform/linux-dpdk/arch/powerpc/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/powerpc/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/powerpc/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/powerpc/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/powerpc/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/powerpc/odp/api/abi/cpu.h
+/* Copyright (c) 2017-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/powerpc/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/powerpc/odp_sysinfo_parse.c

--- a/platform/linux-dpdk/arch/x86/cpu_flags.c
+++ b/platform/linux-dpdk/arch/x86/cpu_flags.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/cpu_flags.c

--- a/platform/linux-dpdk/arch/x86/cpu_flags.h
+++ b/platform/linux-dpdk/arch/x86/cpu_flags.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/cpu_flags.h

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/cpu.h
@@ -1,1 +1,26 @@
-../../../../../../linux-generic/arch/x86/odp/api/abi/cpu.h
+/* Copyright (c) 2016-2018, Linaro Limited
+ * Copyright (c) 2021, Nokia
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <rte_common.h>
+
+#define ODP_CACHE_LINE_SIZE RTE_CACHE_LINE_SIZE
+
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/cpu_inlines.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/cpu.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/cpu.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/x86/odp/api/abi/cpu.h

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_inlines.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_inlines.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/x86/odp/api/abi/cpu_inlines.h

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_rdtsc.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_rdtsc.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/x86/odp/api/abi/cpu_rdtsc.h

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_time.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/cpu_time.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/x86/odp/api/abi/cpu_time.h

--- a/platform/linux-dpdk/arch/x86/odp/api/abi/hash_crc32.h
+++ b/platform/linux-dpdk/arch/x86/odp/api/abi/hash_crc32.h
@@ -1,0 +1,1 @@
+../../../../../../linux-generic/arch/x86/odp/api/abi/hash_crc32.h

--- a/platform/linux-dpdk/arch/x86/odp_cpu.h
+++ b/platform/linux-dpdk/arch/x86/odp_cpu.h
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/odp_cpu.h

--- a/platform/linux-dpdk/arch/x86/odp_cpu_cycles.c
+++ b/platform/linux-dpdk/arch/x86/odp_cpu_cycles.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/odp_cpu_cycles.c

--- a/platform/linux-dpdk/arch/x86/odp_global_time.c
+++ b/platform/linux-dpdk/arch/x86/odp_global_time.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/odp_global_time.c

--- a/platform/linux-dpdk/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-dpdk/arch/x86/odp_sysinfo_parse.c
@@ -1,0 +1,1 @@
+../../../linux-generic/arch/x86/odp_sysinfo_parse.c


### PR DESCRIPTION
V2:

- Rebase
- Added commit 84fb70c