### PR TITLE
[PATCH v2] linux-dpdk: cpu: add configuration option to use static cpu frequency

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.15"
+config_file_version = "0.1.16"
 
 # System options
 system: {
@@ -29,6 +29,14 @@ system: {
 	# odp_cpu_hz_max_id() calls on platforms where max frequency isn't
 	# available using standard Linux methods.
 	cpu_mhz_max = 1400
+
+	# When enabled (1), implementation reads the CPU frequency values from
+	# OS only once during ODP initialization. Enabling this option removes
+	# system calls from odp_cpu_hz() and odp_cpu_hz_id() implementations.
+	#
+	# NOTE: This option should only be used on systems where CPU frequency
+	# scaling is disabled.
+	cpu_hz_static = 0
 
 	# Maximum number of ODP threads that can be created.
 	# odp_thread_count_max() returns this value or the build time

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [15])
+m4_define([_odp_config_version_minor], [16])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/odp_system_info.c
+++ b/platform/linux-dpdk/odp_system_info.c
@@ -25,9 +25,9 @@
 #include <odp/api/align.h>
 #include <odp/api/cpu.h>
 #include <odp_packet_internal.h>
+
 #include <errno.h>
 #include <pthread.h>
-#include <sched.h>
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>
@@ -202,6 +202,21 @@ static uint64_t read_cpufreq(const char *filename, int id)
 	return ret;
 }
 
+static inline uint64_t cpu_hz_current(int id)
+{
+	uint64_t cur_hz = read_cpufreq("cpuinfo_cur_freq", id);
+
+	if (!cur_hz)
+		cur_hz = odp_cpu_arch_hz_current(id);
+
+	return cur_hz;
+}
+
+static inline uint64_t cpu_hz_static(int id)
+{
+	return odp_global_ro.system_info.cpu_hz[id];
+}
+
 /*
  * Analysis of /sys/devices/system/cpu/ files
  */
@@ -263,6 +278,13 @@ static int read_config_file(void)
 	}
 	odp_global_ro.system_info.default_cpu_hz_max = (uint64_t)val * 1000000;
 
+	str = "system.cpu_hz_static";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+	odp_global_ro.system_info.cpu_hz_static = !!val;
+
 	return 0;
 }
 
@@ -289,6 +311,10 @@ int _odp_system_info_init(void)
 		ODP_ERR("Unable to handle all %d "
 			"CPU IDs. Increase CONFIG_NUM_CPU_IDS value.\n",
 			num_cpus);
+
+	/* Read and save all CPU frequencies for static mode */
+	for (i = 0; i < CONFIG_NUM_CPU_IDS; i++)
+		odp_global_ro.system_info.cpu_hz[i] = cpu_hz_current(i);
 
 	/* By default, read max frequency from a cpufreq file */
 	for (i = 0; i < CONFIG_NUM_CPU_IDS; i++) {
@@ -333,26 +359,23 @@ int _odp_system_info_term(void)
  * Public access functions
  *************************
  */
-uint64_t odp_cpu_hz_current(int id)
-{
-	uint64_t cur_hz = read_cpufreq("cpuinfo_cur_freq", id);
-
-	if (!cur_hz)
-		cur_hz = odp_cpu_arch_hz_current(id);
-
-	return cur_hz;
-}
 
 uint64_t odp_cpu_hz(void)
 {
-	int id = sched_getcpu();
+	int id = odp_cpu_id();
 
-	return odp_cpu_hz_current(id);
+	if (odp_global_ro.system_info.cpu_hz_static)
+		return cpu_hz_static(id);
+	return cpu_hz_current(id);
 }
 
 uint64_t odp_cpu_hz_id(int id)
 {
-	return odp_cpu_hz_current(id);
+	ODP_ASSERT(id >= 0 && id < CONFIG_NUM_CPU_IDS);
+
+	if (odp_global_ro.system_info.cpu_hz_static)
+		return cpu_hz_static(id);
+	return cpu_hz_current(id);
 }
 
 uint64_t odp_cpu_hz_max(void)

--- a/platform/linux-dpdk/test/alternate-timer.conf
+++ b/platform/linux-dpdk/test/alternate-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.15"
+config_file_version = "0.1.16"
 
 timer: {
 	# Enable alternate DPDK timer implementation

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.15"
+config_file_version = "0.1.16"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.15"
+config_file_version = "0.1.16"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -11,26 +11,31 @@
 extern "C" {
 #endif
 
-#include <odp/api/init.h>
 #include <odp/api/cpumask.h>
+#include <odp/api/init.h>
 #include <odp/api/random.h>
 #include <odp/api/system_info.h>
-#include <sys/types.h>
+#include <odp/api/std_types.h>
+
+#include <odp_config_internal.h>
+
+#include <libconfig.h>
 #include <pthread.h>
 #include <stdint.h>
-#include <libconfig.h>
-#include <odp_config_internal.h>
+#include <sys/types.h>
 
 #define MODEL_STR_SIZE 128
 #define UID_MAXLEN 30
 
 typedef struct {
 	uint64_t cpu_hz_max[CONFIG_NUM_CPU_IDS];
+	uint64_t cpu_hz[CONFIG_NUM_CPU_IDS];
 	uint64_t default_cpu_hz_max;
 	uint64_t default_cpu_hz;
 	uint64_t page_size;
 	int      cache_line_size;
 	int      cpu_count;
+	odp_bool_t cpu_hz_static;
 	odp_cpu_arch_t cpu_arch;
 	odp_cpu_arch_isa_t cpu_isa_sw;
 	odp_cpu_arch_isa_t cpu_isa_hw;


### PR DESCRIPTION
Add 'system:cpu_hz_static' configuratio option for using a static CPU
frequency value. CPU frequency values returned by odp_cpu_hz() and
odp_cpu_hz_id() calls are read from the OS only once during ODP
initialization. Enabling this option removes system calls from
odp_cpu_hz() and odp_cpu_hz_id() implementations.

NOTE: This option should only be used on systems where CPU frequency
scaling is disabled.

Signed-off-by: Matias Elo <matias.elo@nokia.com>