### PR TITLE
[PATCH v1] linux-dpdk: pool: increase minimum segment length to 2048

### DIFF
--- a/platform/linux-dpdk/include/odp_config_internal.h
+++ b/platform/linux-dpdk/include/odp_config_internal.h
@@ -105,8 +105,11 @@ extern "C" {
  * This defines the minimum packet segment buffer length in bytes. The user
  * defined segment length (seg_len in odp_pool_param_t) will be rounded up into
  * this value.
+ *
+ * Some PMDs operate with 1KB chunks, so 2KB segments are required to receive
+ * standard MTU Ethernet frames without splitting them into multiple segments.
  */
-#define CONFIG_PACKET_SEG_LEN_MIN 1024
+#define CONFIG_PACKET_SEG_LEN_MIN 2048
 
 /*
  * Maximum packet segment length

--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -260,7 +260,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	/* Packet pools */
 	capa->pkt.max_align        = ODP_CONFIG_BUFFER_ALIGN_MIN;
 	capa->pkt.max_pools        = max_pools;
-	capa->pkt.max_len          = 0;
+	capa->pkt.max_len          = CONFIG_PACKET_MAX_SEG_LEN;
 	capa->pkt.max_num	   = _odp_pool_glb->config.pkt_max_num;
 	capa->pkt.min_headroom     = RTE_PKTMBUF_HEADROOM;
 	capa->pkt.max_headroom     = RTE_PKTMBUF_HEADROOM;

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2386,12 +2386,6 @@ static void packet_test_extend_ref(void)
 	odp_packet_push_head(max_pkt, hr);
 	odp_packet_push_tail(max_pkt, tr);
 
-	/* Max packet should not be extendable at either end */
-	if (max_len == pool_capa.pkt.max_len) {
-		CU_ASSERT(odp_packet_extend_tail(&max_pkt, 1, NULL, NULL) < 0);
-		CU_ASSERT(odp_packet_extend_head(&max_pkt, 1, NULL, NULL) < 0);
-	}
-
 	/* See if we can trunc and extend anyway */
 	CU_ASSERT(odp_packet_trunc_tail(&max_pkt, hr + tr + 1,
 					NULL, NULL) >= 0);


### PR DESCRIPTION
Some DPDK PMDs operate with 1KB chunks, so 2KB segments are required to
receive standard MTU Ethernet frames without splitting them into multiple
segments.
