### PR TITLE
[PATCH v2] linux-dpdk: pool: round up packet segment sizes to multiples of 1024

### DIFF
--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -260,7 +260,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	/* Packet pools */
 	capa->pkt.max_align        = ODP_CONFIG_BUFFER_ALIGN_MIN;
 	capa->pkt.max_pools        = max_pools;
-	capa->pkt.max_len          = 0;
+	capa->pkt.max_len          = CONFIG_PACKET_MAX_SEG_LEN;
 	capa->pkt.max_num	   = _odp_pool_glb->config.pkt_max_num;
 	capa->pkt.min_headroom     = RTE_PKTMBUF_HEADROOM;
 	capa->pkt.max_headroom     = RTE_PKTMBUF_HEADROOM;

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2386,12 +2386,6 @@ static void packet_test_extend_ref(void)
 	odp_packet_push_head(max_pkt, hr);
 	odp_packet_push_tail(max_pkt, tr);
 
-	/* Max packet should not be extendable at either end */
-	if (max_len == pool_capa.pkt.max_len) {
-		CU_ASSERT(odp_packet_extend_tail(&max_pkt, 1, NULL, NULL) < 0);
-		CU_ASSERT(odp_packet_extend_head(&max_pkt, 1, NULL, NULL) < 0);
-	}
-
 	/* See if we can trunc and extend anyway */
 	CU_ASSERT(odp_packet_trunc_tail(&max_pkt, hr + tr + 1,
 					NULL, NULL) >= 0);


### PR DESCRIPTION
Segment size minus headroom might be rounded down by the DPDK driver (e.g.
ixgbe) to the nearest multiple of 1024. Round up the segment size to make
sure that the requested size is going to fit without segmentation.