### PR TITLE
[PATCH v2] linux-dpdk: fix linux-generic configuration error

### DIFF
--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/platform/Makefile.inc
+if PLATFORM_IS_LINUX_DPDK
 include $(top_srcdir)/platform/@with_platform@/Makefile.inc
+endif
 lib_LTLIBRARIES += $(LIB)/libodp-dpdk.la
 
 AM_CPPFLAGS  =  $(ODP_INCLUDES)


### PR DESCRIPTION
Fix configuration for linux-generic platform
(--with-platform=linux-generic). Makefile.inc isn't available under
linux-generic platform.

Fixes: https://github.com/OpenDataPlane/odp-dpdk/issues/170

Signed-off-by: Matias Elo <matias.elo@nokia.com>