### PR TITLE
[PATCH v2] ci: update codecov uploader version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -200,7 +200,7 @@ jobs:
         if: ${{ failure() }}
         run: find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v2
 
   Run_distcheck:
     runs-on: ubuntu-18.04

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -24,3 +24,6 @@ pushd ./test/validation/api/
 ODP_SCHEDULER=sp       make check
 popd
 
+# Convert gcno files into gcov (required by Codecov)
+find . -type f -name '*.gcno' -exec gcov -pb {} +
+


### PR DESCRIPTION
Upgrade to Codecov uploader V2 as V1 is being discontinued. The new
uploader doesn't convert *.gcno files into *.gcov files automatically
anymore, so this has to be done now manually in the coverage.sh script.

Signed-off-by: Matias Elo <matias.elo@nokia.com>
Reviewed-by: Tuomas Taipale <tuomas.taipale@nokia.com>