### PR TITLE
[PATCH v2] README: update DPDK-20.11 installation instructions

### DIFF
--- a/platform/linux-dpdk/README
+++ b/platform/linux-dpdk/README
@@ -82,7 +82,8 @@ Prepare the build directory:
     meson build
     cd build
 
-Configure the location where DPDK will be installed:
+Optionally, configure the location where DPDK will be installed. By default,
+DPDK will be installed in /usr/local:
     meson configure -Dprefix=$(pwd)/../install
 
 Build and install DPDK:
@@ -105,7 +106,10 @@ SHARED libraries (requires building DPDK with -fPIC, see above):
 STATIC libraries (better performance):
     ./configure --with-dpdk-path=<dpdk-dir>/install --disable-shared
 
-With DPDK 20.11, instead of --with-dpdk-path option, set PKG_CONFIG_PATH:
+Starting from DPDK 20.11, --with-dpdk-path option is not used anymore:
+    ./configure
+
+Or, if DPDK was not installed to the default location, set PKG_CONFIG_PATH:
     PKG_CONFIG_PATH=<dpdk-dir>/install/lib/x86_64-linux-gnu/pkgconfig ./configure
 
 Once configure has completed successfully:


### PR DESCRIPTION
In the current installation of DPDK-20.11, configuring the location of
DPDK installation to the home directory is a required step. System-wide
installation of DPDK is also an option when ODP-DPDK is not able to link
to DPDK-20.11 by setting of PKG_CONFIG_PATH. This issue was observed on
Arm64 platforms.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>
Reviewed-by: Govindarajan <govindarajan.mohandoss@arm.com>