### PR TITLE
[PATCH v2] linux-dpdk: fix distclean

### DIFF
--- a/platform/linux-dpdk/dumpconfig
+++ b/platform/linux-dpdk/dumpconfig
@@ -1,1 +1,0 @@
-../linux-generic/dumpconfig/

--- a/platform/linux-dpdk/dumpconfig/.gitignore
+++ b/platform/linux-dpdk/dumpconfig/.gitignore
@@ -1,0 +1,1 @@
+odp_linuxdpdk_dumpconfig

--- a/platform/linux-dpdk/dumpconfig/Makefile.am
+++ b/platform/linux-dpdk/dumpconfig/Makefile.am
@@ -1,0 +1,10 @@
+include $(top_srcdir)/Makefile.inc
+
+AM_CPPFLAGS =  -I$(top_builddir)/platform/$(with_platform)/include
+AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/include
+
+bin_PROGRAMS = odp_linuxdpdk_dumpconfig
+
+odp_linuxdpdk_dumpconfig_SOURCES = ../../linux-generic/dumpconfig/dumpconfig.c
+
+TESTS = odp_linuxdpdk_dumpconfig


### PR DESCRIPTION
When making `distclean`, the operation fails while handling
`dumpconfig` as build files (which are currently referenced via a symlink)
are removed in a previous step.

Fix this by creating own `dumpconfig` folder for `linux-dpdk` tree.