### PR TITLE
[PATCH v3] linux-dpdk: crypto: fix return status after pkt linearization failure

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1866,8 +1866,12 @@ int odp_crypto_int(odp_packet_t pkt_in,
 		pkt_in = ODP_PACKET_INVALID;
 	}
 
-	if (linearize_pkt(session, out_pkt))
-		goto err;
+	if (odp_unlikely(linearize_pkt(session, out_pkt))) {
+		result_ok = false;
+		rc_cipher = ODP_CRYPTO_ALG_ERR_DATA_SIZE;
+		rc_auth = ODP_CRYPTO_ALG_ERR_DATA_SIZE;
+		goto out;
+	}
 
 	rte_session = session->rte_session;
 	/* NULL rte_session means that it is a NULL-NULL operation.


### PR DESCRIPTION
If the packet linearization step fails, the input packet may already have been consumed (if a different output packet was requested) or modified (by the linearization step before it failed). Despite this, the current code always returns an error, indicating that the packet was not consumed.

Fix the bug by returning success for the crypto request and by indicating an error in the crypto result of the output packet.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>