### PR TITLE
[PATCH v2] crypto: bug fix and packet allocation optimization

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1846,7 +1846,7 @@ int odp_crypto_int(odp_packet_t pkt_in,
 		int ret;
 		int md_copy;
 
-		md_copy = _odp_packet_copy_md_possible(session->p.output_pool,
+		md_copy = _odp_packet_copy_md_possible(odp_packet_pool(out_pkt),
 						       odp_packet_pool(pkt_in));
 		if (odp_unlikely(md_copy < 0)) {
 			ODP_ERR("Unable to copy packet metadata\n");


### PR DESCRIPTION
These are the same changes as in odp PR 1669 but ported to linux-dpdk:

linux-dpdk: crypto: fix pool checking before metadata copying
linux-dpdk: crypto: reuse input packet as output packet if possible
