### PR TITLE
[PATCH v2] DPDK crypto bug workarounds

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1266,6 +1266,10 @@ static int chained_bufs_ok(const odp_crypto_session_param_t *param,
 	 */
 
 	if (dev_info.driver_name &&
+	    !strcmp(dev_info.driver_name, "crypto_aesni_mb"))
+		chained_bufs_ok = 0;
+
+	if (dev_info.driver_name &&
 	    !strcmp(dev_info.driver_name, "crypto_aesni_gcm") &&
 	    param->auth_alg == ODP_AUTH_ALG_AES_GMAC)
 		chained_bufs_ok = 0;

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1399,6 +1399,13 @@ int odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		return -1;
 	}
 
+	if (param->auth_alg == ODP_AUTH_ALG_AES_GMAC &&
+	    param->cipher_alg != ODP_CIPHER_ALG_NULL) {
+		*status = ODP_CRYPTO_SES_ERR_ALG_COMBO;
+		*session_out = ODP_CRYPTO_SESSION_INVALID;
+		return -1;
+	}
+
 	/* ODP_CRYPTO_OP_TYPE_OOP not supported */
 	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
 		*status = ODP_CRYPTO_SES_ERR_PARAMS;


### PR DESCRIPTION
linux-dpdk: crypto: do not use broken SGL of the aesni_mb device
linux-dpdk: crypto: accept AES-GMAC only with non-null cipher
