### PR TITLE
[PATCH v2] linux-dpdk: pktio: add configuration option for enabling multi segment tx

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # System options
 system: {
@@ -109,6 +109,9 @@ pktio_dpdk: {
 
 	# Enable receipt of Ethernet frames sent to any multicast group
 	multicast_en = 1
+
+	# Enable multi segment transmit offload (RTE_ETH_TX_OFFLOAD_MULTI_SEGS)
+	tx_offload_multi_segs = 0
 
 	# Driver specific options (use PMD names from DPDK)
 	net_ixgbe: {

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -3,7 +3,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [21])
+m4_define([_odp_config_version_minor], [22])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/test/alternate-timer.conf
+++ b/platform/linux-dpdk/test/alternate-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 timer: {
 	# Enable alternate DPDK timer implementation

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation

--- a/platform/linux-dpdk/test/process-mode.conf
+++ b/platform/linux-dpdk/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 dpdk: {
 	process_mode_memory_mb = 1024

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-dpdk/test/stash-custom.conf
+++ b/platform/linux-dpdk/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.21"
+config_file_version = "0.1.22"
 
 # Test overflow safe stash variant
 stash: {


### PR DESCRIPTION
Add new configuration option 'pktio_dpdk:tx_offload_multi_segs' for enabling multi segment transmit offload. This offload may not be supported by some PMDs and may lower maximum throughput, so the options is not enabled by default.