### PR TITLE
[PATCH v2] crypto: improvements with alg combinations

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -575,19 +575,10 @@ static void capability_process(struct rte_cryptodev_info *dev_info,
 				auths->bit.sha512_hmac = 1;
 			if (cap_auth_algo == RTE_CRYPTO_AUTH_AES_GMAC)
 				auths->bit.aes_gmac = 1;
-
-			/* Using AES-CMAC with the aesni_mb driver for IPsec
-			 * causes a crash inside the intel-mb library.
-			 * As a workaround, we do not use AES-CMAC with
-			 * the aesni_mb driver.
-			 */
-			if (cap_auth_algo == RTE_CRYPTO_AUTH_AES_CMAC &&
-			    !is_dev_aesni_mb(dev_info))
+			if (cap_auth_algo == RTE_CRYPTO_AUTH_AES_CMAC)
 				auths->bit.aes_cmac = 1;
-
 			if (cap_auth_algo == RTE_CRYPTO_AUTH_AES_XCBC_MAC)
 				auths->bit.aes_xcbc_mac = 1;
-
 		}
 
 		if (cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD) {
@@ -1192,13 +1183,6 @@ static int is_auth_supported(const struct rte_cryptodev_info *dev_info,
 	if (cap == NULL)
 		return 0;
 
-	/* As a bug workaround, we do not use AES_CMAC with
-	 * the aesni-mb crypto driver.
-	 */
-	if (auth_xform->auth.algo == RTE_CRYPTO_AUTH_AES_CMAC &&
-	    is_dev_aesni_mb(dev_info))
-		return 0;
-
 	/* Check if key size is supported by the algorithm. */
 	if (!is_valid_size(auth_xform->auth.key.length,
 			   &cap->sym.auth.key_size)) {
@@ -1234,10 +1218,10 @@ static int is_combo_buggy(struct rte_cryptodev_info *dev_info,
 	 */
 	if (is_dev_aesni_mb(dev_info)) {
 		if (cipher == RTE_CRYPTO_CIPHER_3DES_CBC &&
-		    auth == RTE_CRYPTO_AUTH_AES_XCBC_MAC)
+		    (auth == RTE_CRYPTO_AUTH_AES_XCBC_MAC ||
+		     auth == RTE_CRYPTO_AUTH_AES_CMAC))
 			return 1;
 	}
-
 	return 0;
 }
 

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -531,6 +531,9 @@ static void capability_process(struct rte_cryptodev_info *dev_info,
 	for (cap = &dev_info->capabilities[0];
 	     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED;
 	     cap++) {
+		if (cap->op != RTE_CRYPTO_OP_TYPE_SYMMETRIC)
+			continue;
+
 		if (cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_CIPHER) {
 			enum rte_crypto_cipher_algorithm cap_cipher_algo;
 
@@ -755,7 +758,8 @@ static int cipher_aead_capability(odp_cipher_alg_t cipher,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
 		       cap->sym.aead.algo == aead_xform.aead.algo);
 		     cap++)
 			;
@@ -807,7 +811,8 @@ static int cipher_capability(odp_cipher_alg_t cipher,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_CIPHER &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_CIPHER &&
 		       cap->sym.cipher.algo == cipher_xform.cipher.algo);
 		     cap++)
 			;
@@ -967,7 +972,8 @@ static int auth_aead_capability(odp_auth_alg_t auth,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
 		       cap->sym.auth.algo == aead_xform.auth.algo);
 		     cap++)
 			;
@@ -1054,7 +1060,8 @@ static int auth_capability(odp_auth_alg_t auth,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AUTH &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AUTH &&
 		       cap->sym.auth.algo == auth_xform.auth.algo);
 		     cap++)
 			;
@@ -1116,7 +1123,8 @@ static int get_crypto_aead_dev(struct rte_crypto_sym_xform *aead_xform,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AEAD &&
 		       cap->sym.aead.algo == aead_xform->aead.algo);
 		     cap++)
 			;
@@ -1170,7 +1178,8 @@ static int get_crypto_dev(struct rte_crypto_sym_xform *cipher_xform,
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_CIPHER &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_CIPHER &&
 		       cap->sym.cipher.algo == cipher_xform->cipher.algo);
 		     cap++)
 			;
@@ -1200,7 +1209,8 @@ check_auth:
 
 		for (cap = &dev_info.capabilities[0];
 		     cap->op != RTE_CRYPTO_OP_TYPE_UNDEFINED &&
-		     !(cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AUTH &&
+		     !(cap->op == RTE_CRYPTO_OP_TYPE_SYMMETRIC &&
+		       cap->sym.xform_type == RTE_CRYPTO_SYM_XFORM_AUTH &&
 		       cap->sym.auth.algo == auth_xform->auth.algo);
 		     cap++)
 			;


### PR DESCRIPTION
linux-dpdk: crypto: fix capability query to ignore asymmetric algs
linux-dpdk: crypto: deduplicate some capability matching code
linux-dpdk: crypto: improve returned session creation error codes
linux-dpdk: crypto: partially re-enable aes-xcbc-mac with aesni_mb
linux-dpdk: crypto: partially re-enable aes-cmac with aesni_mb
