### PR TITLE
[PATCH v6] linux-dpdk: pool: refactor internal pool creation function

### DIFF
--- a/platform/linux-dpdk/include/event_vector_internal.h
+++ b/platform/linux-dpdk/include/event_vector_internal.h
@@ -1,1 +1,0 @@
-../../linux-generic/include/odp_event_vector_internal.h

--- a/platform/linux-dpdk/include/odp_buffer_internal.h
+++ b/platform/linux-dpdk/include/odp_buffer_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
+ * Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -49,8 +49,11 @@ extern "C" {
 
 /* Internal buffer header */
 typedef struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
-	/* Common event header */
-	_odp_event_hdr_t event_hdr;
+	/* Underlying DPDK rte_mbuf */
+	struct rte_mbuf mb;
+
+	/* Common internal header */
+	_odp_event_hdr_int_t event_hdr;
 
 	/* User area pointer */
 	void *uarea_addr;

--- a/platform/linux-dpdk/include/odp_event_internal.h
+++ b/platform/linux-dpdk/include/odp_event_internal.h
@@ -33,11 +33,7 @@ extern "C" {
 	#undef vector
 #endif
 
-/* Common header for all event types. */
-typedef struct _odp_event_hdr_t {
-	/* Underlying DPDK rte_mbuf */
-	struct rte_mbuf mb;
-
+typedef struct _odp_event_hdr_int_t {
 	/* Pool handle */
 	odp_pool_t pool;
 
@@ -52,6 +48,17 @@ typedef struct _odp_event_hdr_t {
 
 	/* Event flow id */
 	uint8_t   flow_id;
+
+} _odp_event_hdr_int_t;
+
+/* Common header for all event types. Helper for casting, actual pool element types should begin
+ * with explicit struct rte_mbuf and _odp_event_hdr_int_t fields. */
+typedef struct ODP_ALIGNED_CACHE _odp_event_hdr_t {
+	/* Underlying DPDK rte_mbuf */
+	struct rte_mbuf mb;
+
+	/* Common internal header */
+	_odp_event_hdr_int_t hdr;
 
 } _odp_event_hdr_t;
 
@@ -77,7 +84,7 @@ static inline struct rte_mbuf *_odp_event_to_mbuf(odp_event_t event)
 
 static inline void _odp_event_type_set(odp_event_t event, int ev)
 {
-	_odp_event_hdr(event)->event_type = ev;
+	_odp_event_hdr(event)->hdr.event_type = ev;
 }
 
 static inline uint64_t *_odp_event_endmark_get_ptr(odp_event_t event)

--- a/platform/linux-dpdk/include/odp_event_vector_internal.h
+++ b/platform/linux-dpdk/include/odp_event_vector_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2022, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -27,8 +27,11 @@
  * Internal event vector header
  */
 typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
-	/* Common event header */
-	_odp_event_hdr_t event_hdr;
+	/* Underlying DPDK rte_mbuf */
+	struct rte_mbuf mb;
+
+	/* Common internal header */
+	_odp_event_hdr_int_t event_hdr;
 
 	/* User area pointer */
 	void *uarea_addr;
@@ -50,6 +53,14 @@ typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
 static inline odp_event_vector_hdr_t *_odp_packet_vector_hdr(odp_packet_vector_t pktv)
 {
 	return (odp_event_vector_hdr_t *)(uintptr_t)pktv;
+}
+
+/**
+ * Return the event header
+ */
+static inline _odp_event_hdr_t *_odp_packet_vector_to_event_hdr(odp_packet_vector_t pktv)
+{
+	return (_odp_event_hdr_t *)(uintptr_t)_odp_packet_vector_hdr(pktv);
 }
 
 /**

--- a/platform/linux-dpdk/include/odp_timer_internal.h
+++ b/platform/linux-dpdk/include/odp_timer_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014-2018, Linaro Limited
- * Copyright (c) 2021-2022, Nokia
+ * Copyright (c) 2021-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -26,8 +26,11 @@
  * Internal Timeout header
  */
 typedef struct ODP_ALIGNED_CACHE odp_timeout_hdr_t {
-	/* Common event header */
-	_odp_event_hdr_t event_hdr;
+	/* Underlying DPDK rte_mbuf */
+	struct rte_mbuf mb;
+
+	/* Common internal header */
+	_odp_event_hdr_int_t event_hdr;
 
 	/* Requested expiration time */
 	uint64_t expiration;

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1662,10 +1662,8 @@ static uint8_t *crypto_prepare_digest(const crypto_session_entry_t *session,
 					     session->p.auth_digest_len);
 	}
 	data = pkt_hdr->crypto_digest_buf;
-	mb = &pkt_hdr->event_hdr.mb;
-	*phys_addr =
-		rte_pktmbuf_iova_offset(mb, data -
-					rte_pktmbuf_mtod(mb, uint8_t *));
+	mb = &pkt_hdr->mb;
+	*phys_addr = rte_pktmbuf_iova_offset(mb, data - rte_pktmbuf_mtod(mb, uint8_t *));
 
 	return data;
 }
@@ -1693,10 +1691,9 @@ static void crypto_fill_aead_param(const crypto_session_entry_t *session,
 		       session->p.auth_aad_len);
 	op->sym->aead.aad.data = pkt_hdr->crypto_aad_buf;
 	op->sym->aead.aad.phys_addr =
-		rte_pktmbuf_iova_offset(&pkt_hdr->event_hdr.mb,
+		rte_pktmbuf_iova_offset(&pkt_hdr->mb,
 					op->sym->aead.aad.data -
-					rte_pktmbuf_mtod(&pkt_hdr->event_hdr.mb,
-							 uint8_t *));
+					rte_pktmbuf_mtod(&pkt_hdr->mb, uint8_t *));
 	iv_ptr = rte_crypto_op_ctod_offset(op, uint8_t *, IV_OFFSET);
 	if (session->p.cipher_alg == ODP_CIPHER_ALG_AES_CCM) {
 		*iv_ptr = iv_len;

--- a/platform/linux-dpdk/odp_event.c
+++ b/platform/linux-dpdk/odp_event.c
@@ -34,10 +34,10 @@
 /* Fill in event header field offsets for inline functions */
 const _odp_event_inline_offset_t
 _odp_event_inline_offset ODP_ALIGNED_CACHE = {
-	.event_type = offsetof(_odp_event_hdr_t, event_type),
+	.event_type = offsetof(_odp_event_hdr_t, hdr.event_type),
 	.base_data  = offsetof(_odp_event_hdr_t, mb.buf_addr),
-	.flow_id    = offsetof(_odp_event_hdr_t, flow_id),
-	.pool       = offsetof(_odp_event_hdr_t, pool),
+	.flow_id    = offsetof(_odp_event_hdr_t, hdr.flow_id),
+	.pool       = offsetof(_odp_event_hdr_t, hdr.pool),
 	.buf_len    = offsetof(_odp_event_hdr_t, mb.buf_len)
 };
 

--- a/platform/linux-dpdk/odp_packet.c
+++ b/platform/linux-dpdk/odp_packet.c
@@ -54,7 +54,7 @@
 /* Fill in packet header field offsets for inline functions */
 
 const _odp_packet_inline_offset_t _odp_packet_inline ODP_ALIGNED_CACHE = {
-	.mb               = offsetof(odp_packet_hdr_t, event_hdr.mb),
+	.mb               = offsetof(odp_packet_hdr_t, mb),
 	.pool             = offsetof(odp_packet_hdr_t, event_hdr.pool),
 	.input            = offsetof(odp_packet_hdr_t, input),
 	.user_ptr         = offsetof(odp_packet_hdr_t, user_ptr),
@@ -68,14 +68,14 @@ const _odp_packet_inline_offset_t _odp_packet_inline ODP_ALIGNED_CACHE = {
 	.cls_mark         = offsetof(odp_packet_hdr_t, cls_mark),
 	.ipsec_ctx        = offsetof(odp_packet_hdr_t, ipsec_ctx),
 	.crypto_op        = offsetof(odp_packet_hdr_t, crypto_op_result),
-	.buf_addr         = offsetof(odp_packet_hdr_t, event_hdr.mb.buf_addr),
-	.data             = offsetof(odp_packet_hdr_t, event_hdr.mb.data_off),
-	.pkt_len          = offsetof(odp_packet_hdr_t, event_hdr.mb.pkt_len),
-	.seg_len          = offsetof(odp_packet_hdr_t, event_hdr.mb.data_len),
-	.nb_segs          = offsetof(odp_packet_hdr_t, event_hdr.mb.nb_segs),
+	.buf_addr         = offsetof(odp_packet_hdr_t, mb.buf_addr),
+	.data             = offsetof(odp_packet_hdr_t, mb.data_off),
+	.pkt_len          = offsetof(odp_packet_hdr_t, mb.pkt_len),
+	.seg_len          = offsetof(odp_packet_hdr_t, mb.data_len),
+	.nb_segs          = offsetof(odp_packet_hdr_t, mb.nb_segs),
 	.user_area        = offsetof(odp_packet_hdr_t, uarea_addr),
-	.rss              = offsetof(odp_packet_hdr_t, event_hdr.mb.hash.rss),
-	.ol_flags         = offsetof(odp_packet_hdr_t, event_hdr.mb.ol_flags),
+	.rss              = offsetof(odp_packet_hdr_t, mb.hash.rss),
+	.ol_flags         = offsetof(odp_packet_hdr_t, mb.ol_flags),
 	.rss_flag         = RTE_MBUF_F_RX_RSS_HASH
 };
 
@@ -132,7 +132,7 @@ static inline int num_segments(uint32_t len, uint32_t seg_len)
 static inline int packet_reset(odp_packet_t pkt, uint32_t len)
 {
 	odp_packet_hdr_t *const pkt_hdr = packet_hdr(pkt);
-	struct rte_mbuf *ms, *mb = &pkt_hdr->event_hdr.mb;
+	struct rte_mbuf *ms, *mb = &pkt_hdr->mb;
 	uint8_t nb_segs = 0;
 	int32_t lenleft = len;
 
@@ -354,7 +354,7 @@ int odp_event_filter_packet(const odp_event_t event[],
 
 void *odp_packet_tail(odp_packet_t pkt)
 {
-	struct rte_mbuf *mb = &(packet_hdr(pkt)->event_hdr.mb);
+	struct rte_mbuf *mb = &(packet_hdr(pkt)->mb);
 
 	mb = rte_pktmbuf_lastseg(mb);
 	return (void *)(rte_pktmbuf_mtod(mb, char *) + mb->data_len);
@@ -362,7 +362,7 @@ void *odp_packet_tail(odp_packet_t pkt)
 
 void *odp_packet_push_head(odp_packet_t pkt, uint32_t len)
 {
-	struct rte_mbuf *mb = &(packet_hdr(pkt)->event_hdr.mb);
+	struct rte_mbuf *mb = &(packet_hdr(pkt)->mb);
 
 	return (void *)rte_pktmbuf_prepend(mb, len);
 }
@@ -378,7 +378,7 @@ static void _copy_head_metadata(struct rte_mbuf *newhead,
 int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len, void **data_ptr,
 			   uint32_t *seg_len)
 {
-	struct rte_mbuf *mb = &(packet_hdr(*pkt)->event_hdr.mb);
+	struct rte_mbuf *mb = &(packet_hdr(*pkt)->mb);
 	int addheadsize = len - rte_pktmbuf_headroom(mb);
 
 	if (addheadsize > 0) {
@@ -482,7 +482,7 @@ int odp_packet_trunc_head(odp_packet_t *pkt, uint32_t len, void **data_ptr,
 
 void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len)
 {
-	struct rte_mbuf *mb = &(packet_hdr(pkt)->event_hdr.mb);
+	struct rte_mbuf *mb = &(packet_hdr(pkt)->mb);
 
 	return (void *)rte_pktmbuf_append(mb, len);
 }
@@ -490,7 +490,7 @@ void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len)
 int odp_packet_extend_tail(odp_packet_t *pkt, uint32_t len, void **data_ptr,
 			   uint32_t *seg_len)
 {
-	struct rte_mbuf *mb = &(packet_hdr(*pkt)->event_hdr.mb);
+	struct rte_mbuf *mb = &(packet_hdr(*pkt)->mb);
 	int newtailsize = len - odp_packet_tailroom(*pkt);
 	uint32_t old_pkt_len = odp_packet_len(*pkt);
 
@@ -1041,7 +1041,7 @@ void odp_packet_print(odp_packet_t pkt)
 	len += _odp_snprint(&str[len], n - len,
 			    "  l4_offset      %" PRIu32 "\n", hdr->p.l4_offset);
 	len += _odp_snprint(&str[len], n - len,
-			    "  frame_len      %" PRIu32 "\n", hdr->event_hdr.mb.pkt_len);
+			    "  frame_len      %" PRIu32 "\n", hdr->mb.pkt_len);
 	len += _odp_snprint(&str[len], n - len,
 			    "  input          %" PRIu64 "\n", odp_pktio_to_u64(hdr->input));
 	len += _odp_snprint(&str[len], n - len,
@@ -1089,7 +1089,7 @@ void odp_packet_print_data(odp_packet_t pkt, uint32_t offset,
 	len += _odp_snprint(&str[len], n - len,
 			    "  buf index      %" PRIu32 "\n", hdr->event_hdr.index);
 	len += _odp_snprint(&str[len], n - len,
-			    "  segcount       %" PRIu8 "\n", hdr->event_hdr.mb.nb_segs);
+			    "  segcount       %" PRIu8 "\n", hdr->mb.nb_segs);
 	len += _odp_snprint(&str[len], n - len,
 			    "  data len       %" PRIu32 "\n", data_len);
 	len += _odp_snprint(&str[len], n - len,
@@ -1528,7 +1528,7 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	 * packet data range. Copy enough data to a temporary buffer for
 	 * parsing if necessary.
 	 */
-	if (odp_unlikely(pkt_hdr->event_hdr.mb.nb_segs > 1) &&
+	if (odp_unlikely(pkt_hdr->mb.nb_segs > 1) &&
 	    odp_unlikely(seg_len < min_seglen)) {
 		seg_len = min_seglen;
 		if (seg_len > packet_len - offset)
@@ -1892,15 +1892,15 @@ odp_packet_t odp_packet_reassemble(odp_pool_t pool_hdl,
 		if (i < num - 1)
 			next_seg = (odp_packet_hdr_t *)(uintptr_t)pkt_buf[i + 1];
 
-		data_len += cur_seg->event_hdr.mb.data_len;
+		data_len += cur_seg->mb.data_len;
 		mb = (struct rte_mbuf *)(uintptr_t)cur_seg;
 		mb->next = (struct rte_mbuf *)next_seg;
 		cur_seg = next_seg;
 	}
 
-	pkt_hdr->event_hdr.mb.nb_segs = num;
-	pkt_hdr->event_hdr.mb.pkt_len = data_len;
-	pkt_hdr->event_hdr.mb.data_off = headroom;
+	pkt_hdr->mb.nb_segs = num;
+	pkt_hdr->mb.pkt_len = data_len;
+	pkt_hdr->mb.data_off = headroom;
 
 	/* Reset metadata */
 	pkt_hdr->subtype = ODP_EVENT_PACKET_BASIC;

--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -235,10 +235,10 @@ int _odp_event_is_valid(odp_event_t event)
 	if (pool == NULL)
 		return 0;
 
-	if (pool != _odp_pool_entry(event_hdr->pool))
+	if (pool != _odp_pool_entry(event_hdr->hdr.pool))
 		return 0;
 
-	if (event_hdr->index >= pool->rte_mempool->size)
+	if (event_hdr->hdr.index >= pool->rte_mempool->size)
 		return 0;
 
 	return 1;
@@ -612,10 +612,10 @@ static void init_obj_priv_data(struct rte_mempool *mp ODP_UNUSED, void *arg, voi
 		/* No need for headroom in non-packet objects */
 		mb->data_off = 0;
 
-	event_hdr->index = i;
-	event_hdr->pool = _odp_pool_handle(priv_data->pool);
-	event_hdr->type = priv_data->type;
-	event_hdr->event_type = priv_data->event_type;
+	event_hdr->hdr.index = i;
+	event_hdr->hdr.pool = _odp_pool_handle(priv_data->pool);
+	event_hdr->hdr.type = priv_data->type;
+	event_hdr->hdr.event_type = priv_data->event_type;
 
 	switch (priv_data->type) {
 	case ODP_POOL_BUFFER:
@@ -1286,10 +1286,10 @@ static void init_ext_obj(struct rte_mempool *mp, void *arg, void *mbuf, unsigned
 	rte_mbuf_refcnt_set(mb, 1);
 	mb->next = NULL;
 	/* Save index, might be useful for debugging purposes */
-	event_hdr->index = i;
-	event_hdr->pool = _odp_pool_handle(mb_ctor_arg->pool);
-	event_hdr->type = mb_ctor_arg->type;
-	event_hdr->event_type = mb_ctor_arg->event_type;
+	event_hdr->hdr.index = i;
+	event_hdr->hdr.pool = _odp_pool_handle(mb_ctor_arg->pool);
+	event_hdr->hdr.type = mb_ctor_arg->type;
+	event_hdr->hdr.event_type = mb_ctor_arg->event_type;
 
 	switch (mb_ctor_arg->type) {
 	case ODP_POOL_BUFFER:

--- a/platform/linux-dpdk/odp_pool.c
+++ b/platform/linux-dpdk/odp_pool.c
@@ -58,7 +58,7 @@
 #define POOL_NAME_FORMAT "%" PRIu64 "-%d-%s"
 
 /* Define a practical limit for contiguous memory allocations */
-#define MAX_SIZE   (10 * 1024 * 1024)
+#define MAX_SIZE   (CONFIG_PACKET_SEG_SIZE - ODP_CONFIG_BUFFER_ALIGN_MIN)
 
 /* Maximum packet user area size */
 #define MAX_UAREA_SIZE 2048

--- a/platform/linux-generic/include/odp_event_vector_internal.h
+++ b/platform/linux-generic/include/odp_event_vector_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020-2021, Nokia
+/* Copyright (c) 2020-2023, Nokia
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -55,6 +55,14 @@ ODP_STATIC_ASSERT(sizeof(odp_event_vector_hdr_t) <= ODP_CACHE_LINE_SIZE,
 static inline odp_event_vector_hdr_t *_odp_packet_vector_hdr(odp_packet_vector_t pktv)
 {
 	return (odp_event_vector_hdr_t *)(uintptr_t)pktv;
+}
+
+/**
+ * Return the event header
+ */
+static inline _odp_event_hdr_t *_odp_packet_vector_to_event_hdr(odp_packet_vector_t pktv)
+{
+	return (_odp_event_hdr_t *)(uintptr_t)&_odp_packet_vector_hdr(pktv)->event_hdr;
 }
 
 /**

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -72,11 +72,6 @@ static inline pktio_entry_t *pktio_entry_by_index(int index)
 	return _odp_pktio_entry_ptr[index];
 }
 
-static inline _odp_event_hdr_t *packet_vector_to_event_hdr(odp_packet_vector_t pktv)
-{
-	return (_odp_event_hdr_t *)(uintptr_t)&_odp_packet_vector_hdr(pktv)->event_hdr;
-}
-
 static int read_config_file(pktio_global_t *pktio_glb)
 {
 	const char *str;
@@ -950,7 +945,7 @@ static inline int pktin_recv_buf(pktio_entry_t *entry, int pktin_index,
 		if (odp_unlikely(pktv == ODP_PACKET_VECTOR_INVALID))
 			return 0;
 
-		event_hdrs[0] = packet_vector_to_event_hdr(pktv);
+		event_hdrs[0] = _odp_packet_vector_to_event_hdr(pktv);
 		return 1;
 	}
 

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -1379,12 +1379,11 @@ static uint32_t pkts_rcvd_in_given_order(uint32_t   unique_id_list[],
 {
 	rcv_pkt_desc_t *rcv_pkt_desc;
 	odp_bool_t      is_match;
-	uint32_t        rcv_pkt_idx, pkts_in_order, pkts_out_of_order;
+	uint32_t        rcv_pkt_idx, pkts_in_order;
 	uint32_t        rcv_unique_id;
 	int             last_pkt_idx, pkt_idx;
 
 	pkts_in_order     = 1;
-	pkts_out_of_order = 0;
 	last_pkt_idx      = -1;
 	pkt_idx           = -1;
 
@@ -1404,12 +1403,8 @@ static uint32_t pkts_rcvd_in_given_order(uint32_t   unique_id_list[],
 							   unique_id_list,
 							   unique_id_list_len);
 			if (0 <= pkt_idx) {
-				if (0 <= last_pkt_idx) {
-					if (last_pkt_idx < pkt_idx)
-						pkts_in_order++;
-					else
-						pkts_out_of_order++;
-				}
+				if (0 <= last_pkt_idx && last_pkt_idx < pkt_idx)
+					pkts_in_order++;
 
 				last_pkt_idx = pkt_idx;
 			}


### PR DESCRIPTION
Refactor and clean up `_odp_pool_create()`:
  - Create all underlying RTE memory pool types with `rte_pktmbuf_pool_create()` instead of using `rte_mempool_create()` for other than packet pools as RTE mbuf is always assumed to precede ODP specific data
  - Simplify memory pool object initialization
  - Utilize `RTE_MBUF_PRIV_ALIGN` for memory pool element private area alignment

Additionally, remove `struct rte_mbuf` from common event header for potential pool element size savings.

v2:
- Fix checkpatch complaints
- Add debug print to pool creation once RTE mempool arguments have been resolved and calculated

v4:
- Matias' comments
- Removed seemingly unnecessary symbolic link to `linux-generic/include/odp_event_vector_internal.h`