### PR TITLE
[PATCH v2] linux-dpdk: pool: add checks for internal event header sizes

### DIFF
--- a/platform/linux-dpdk/include/odp_buffer_internal.h
+++ b/platform/linux-dpdk/include/odp_buffer_internal.h
@@ -60,6 +60,9 @@ typedef struct ODP_ALIGNED_CACHE odp_buffer_hdr_t {
 
 } odp_buffer_hdr_t;
 
+ODP_STATIC_ASSERT(sizeof(odp_buffer_hdr_t) <= 3 * RTE_CACHE_LINE_SIZE,
+		  "Additional cache line required for odp_buffer_hdr_t");
+
 static inline struct rte_mbuf *_odp_buf_to_mbuf(odp_buffer_t buf)
 {
 	return (struct rte_mbuf *)(uintptr_t)buf;

--- a/platform/linux-dpdk/include/odp_event_vector_internal.h
+++ b/platform/linux-dpdk/include/odp_event_vector_internal.h
@@ -21,6 +21,8 @@
 
 #include <odp_event_internal.h>
 
+#include <rte_config.h>
+
 #include <stdint.h>
 
 /**
@@ -46,6 +48,9 @@ typedef struct ODP_ALIGNED_CACHE odp_event_vector_hdr_t {
 	odp_packet_t packet[];
 
 } odp_event_vector_hdr_t;
+
+ODP_STATIC_ASSERT(sizeof(odp_event_vector_hdr_t) <= 3 * RTE_CACHE_LINE_SIZE,
+		  "Additional cache line required for odp_event_vector_hdr_t");
 
 /**
  * Return the vector header

--- a/platform/linux-dpdk/include/odp_packet_internal.h
+++ b/platform/linux-dpdk/include/odp_packet_internal.h
@@ -184,6 +184,9 @@ typedef struct ODP_ALIGNED_CACHE odp_packet_hdr_t {
 	uint8_t crypto_aad_buf[PACKET_AAD_MAX];
 } odp_packet_hdr_t;
 
+ODP_STATIC_ASSERT(sizeof(odp_packet_hdr_t) <= 6 * RTE_CACHE_LINE_SIZE,
+		  "Additional cache line required for odp_packet_hdr_t");
+
 /**
  * Return the packet header
  */

--- a/platform/linux-dpdk/include/odp_timer_internal.h
+++ b/platform/linux-dpdk/include/odp_timer_internal.h
@@ -22,6 +22,8 @@
 #include <odp_global_data.h>
 #include <odp_pool_internal.h>
 
+#include <rte_config.h>
+
 /**
  * Internal Timeout header
  */
@@ -45,6 +47,9 @@ typedef struct ODP_ALIGNED_CACHE odp_timeout_hdr_t {
 	odp_timer_t timer;
 
 } odp_timeout_hdr_t;
+
+ODP_STATIC_ASSERT(sizeof(odp_timeout_hdr_t) <= 3 * RTE_CACHE_LINE_SIZE,
+		  "Additional cache line required for odp_timeout_hdr_t");
 
 /* A larger decrement value should be used after receiving events compared to
  * an 'empty' call. */


### PR DESCRIPTION
Add compile time checks for implementation internal event header sizes. Detect if a size of an event header expands to a new cache line, as this may have significant performance implications.

RTE_CACHE_LINE_SIZE is used instead of ODP_CACHE_LINE_SIZE because in ABI compat mode the values may differ.