### PR TITLE
[PATCH v2] linux-dpdk: crypto: reject all unsupported op types

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1448,8 +1448,8 @@ int odp_crypto_session_create(const odp_crypto_session_param_t *param,
 		return -1;
 	}
 
-	/* ODP_CRYPTO_OP_TYPE_OOP not supported */
-	if (param->op_type == ODP_CRYPTO_OP_TYPE_OOP) {
+	if (param->op_type != ODP_CRYPTO_OP_TYPE_BASIC &&
+	    param->op_type != ODP_CRYPTO_OP_TYPE_LEGACY) {
 		*status = ODP_CRYPTO_SES_ERR_PARAMS;
 		*session_out = ODP_CRYPTO_SESSION_INVALID;
 		return -1;


### PR DESCRIPTION
Reverse the logic of operation type checking at session creation so that session creation fails if the operation type is not one of the supported types. After this the OOP op type continues to be rejected but also new types defined in future API versions will get rejected until support for them is added.