### PR TITLE
[PATCH v3] m4: dpdk: fix DPDK_LIBS generation with pkgconf >= 1.9.4

### DIFF
--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -49,14 +49,14 @@ AS_IF([test "x$DPDK_SHARED" = "xyes"], [dnl
       # static linking flags will need -ldpdk
       DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"
     fi
-    DPDK_LIBS="-Wl,--no-as-needed,-ldpdk,--as-needed,`echo $DPDK_LIBS | sed -e 's/ /,/g'`"
+    DPDK_LIBS="-Wl,--no-as-needed,-ldpdk,--as-needed,`echo $DPDK_LIBS | sed -e 's/ /,/g' -e 's/,*$/,/'`"
     DPDK_LIBS="$DPDK_LDFLAGS $DPDK_RPATH $DPDK_LIBS"
     # link libodp-linux with -ldpdk
     DPDK_LIBS_LIBODP="$DPDK_LIBS"
 ], [dnl
     # build long list of libraries for applications, which should not be
     # rearranged by libtool
-    DPDK_LIBS_LT="`echo $DPDK_LIBS | sed -e 's/^/-Wc,/' -e 's/ /,/g'`"
+    DPDK_LIBS_LT="`echo $DPDK_LIBS | sed -e 's/^/-Wc,/' -e 's/ /,/g' -e 's/,*$/,/'`"
     DPDK_LIBS_LT="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS_LT $DPDK_LIBS"
     # static linking flags follow the suite
     DPDK_LIBS="$DPDK_LDFLAGS $DPDK_LIB $DPDK_LIBS"


### PR DESCRIPTION
The pkgconf older then 1.9.4 was adding extra space at the end of printed configuration elements. This was changed with [1].

With pkgconf 1.9.4 onwards the generated DPDK_LIBS creates '-ldl-latomic' instaed of '-ldl,-latomic' causing that linking fails.

To fix this append ',' always if missing at the end. The change is backwards compatible and works with both old and new pkgconf.

[1] https://github.com/pkgconf/pkgconf/commit/648a2249fcb10bf679bdb587ef2bbddaab3023ad