### PR TITLE
[PATCH v2] linux-dpdk: dma: simplify inflight transfer bookkeeping

### DIFF
--- a/platform/linux-dpdk/include/odp_config_internal.h
+++ b/platform/linux-dpdk/include/odp_config_internal.h
@@ -34,10 +34,10 @@ extern "C" {
 #define CONFIG_MAX_DMA_SESSIONS 32
 
 /*
- * Pools reserved for internal usage, 1 for IPsec status events, one per packet
- * I/O for TX completion and one per DMA session
+ * Pools reserved for internal usage, 1 for IPsec status events and one per packet
+ * I/O for TX completion
  */
-#define CONFIG_INTERNAL_POOLS (1 + CONFIG_PKTIO_ENTRIES + CONFIG_MAX_DMA_SESSIONS)
+#define CONFIG_INTERNAL_POOLS (1 + CONFIG_PKTIO_ENTRIES)
 
 /*
  * Maximum number of pools


### PR DESCRIPTION
Instead of having a separate buffer-backed structure for bookkeeping inflight transfers, use the transfer structures themselves. This removes the need for an additional buffer pool for each DMA session.

Additionally, utilize `<queue.h>` provided iteration macro instead of accessing private fields directly when looping queue structures.

v2:
- Added reviewed-by tag