### PR TITLE
[PATCH v3] crypto: misc improvements and fixes for CI

### DIFF
--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 # System options
 system: {
@@ -285,6 +285,11 @@ timer: {
 
 	# Use DPDK alternate timer API based implementation
 	alternate = 1
+}
+
+crypto: {
+	# Maximum number of crypto sessions
+	max_num_sessions = 100
 }
 
 ipsec: {

--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # System options
 system: {
@@ -290,6 +290,24 @@ timer: {
 crypto: {
 	# Maximum number of crypto sessions
 	max_num_sessions = 100
+
+	# Allow queue pair sharing
+	#
+	# Allow different ODP threads use the same queue pair when accessing
+	# a crypto device. This makes it possible to use a crypto device even
+	# when it does not support enough queue pairs for the maximum number
+	# of ODP threads (see also the system.thread_count_max ODP config
+	# option and the max_nb_queue_pairs DPDK crypto device parameter).
+	#
+	# If there are enough queue pairs for the number of threads, queue
+	# pairs will not be shared even if allowed.
+	#
+	# If queue pair sharing is not allowed but would be required for some
+	# crypto device, ODP initialization will fail.
+	#
+	# Queue pair sharing should be avoided as it has a high performance
+	# penalty.
+	allow_queue_pair_sharing = 0
 }
 
 ipsec: {

--- a/config/odp-linux-dpdk.conf
+++ b/config/odp-linux-dpdk.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # System options
 system: {
@@ -308,6 +308,19 @@ crypto: {
 	# Queue pair sharing should be avoided as it has a high performance
 	# penalty.
 	allow_queue_pair_sharing = 0
+
+	# Settings for the openssl crypto device
+	openssl: {
+		# Disable AES CMAC algorithm
+		#
+		# AES CMAC is broken in the openssl crypto device of DPDK
+		# when the version of the underlying openssl library is 1.x.
+		#
+		# Since ODP cannot easily detect the openssl version, this
+		# setting can be used for disabling AES CMAC in environments
+		# affected by the DPDK bug.
+		disable_aes_cmac = 1;
+	}
 }
 
 ipsec: {

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -7,7 +7,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [28])
+m4_define([_odp_config_version_minor], [29])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -7,7 +7,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [29])
+m4_define([_odp_config_version_minor], [30])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/m4/odp_libconfig.m4
+++ b/platform/linux-dpdk/m4/odp_libconfig.m4
@@ -7,7 +7,7 @@
 ##########################################################################
 m4_define([_odp_config_version_generation], [0])
 m4_define([_odp_config_version_major], [1])
-m4_define([_odp_config_version_minor], [27])
+m4_define([_odp_config_version_minor], [28])
 
 m4_define([_odp_config_version],
           [_odp_config_version_generation._odp_config_version_major._odp_config_version_minor])

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -335,7 +335,7 @@ int _odp_crypto_init_global(void)
 {
 	size_t mem_size;
 	int idx;
-	int16_t cdev_id, cdev_count;
+	uint8_t cdev_id, cdev_count;
 	int rc = -1;
 	unsigned int pool_size;
 	unsigned int nb_queue_pairs = 0, queue_pair;
@@ -391,7 +391,7 @@ int _odp_crypto_init_global(void)
 			max_sess_sz = sess_sz;
 	}
 
-	for (cdev_id = cdev_count - 1; cdev_id >= 0; cdev_id--) {
+	for (cdev_id = 0; cdev_id < cdev_count; cdev_id++) {
 		struct rte_cryptodev_info dev_info;
 		struct rte_mempool *mp;
 		odp_bool_t queue_pairs_shared = false;

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -710,18 +710,22 @@ int odp_crypto_capability(odp_crypto_capability_t *capability)
 
 	for (int n = 0; n < global->num_devs; n++) {
 		struct rte_cryptodev_info dev_info;
+		odp_crypto_cipher_algos_t ciphers = {.all_bits = 0};
+		odp_crypto_auth_algos_t auths = {.all_bits = 0};
 
 		rte_cryptodev_info_get(global->devs[n].dev_id, &dev_info);
-		capability_process(&dev_info, &capability->ciphers,
-				   &capability->auths);
+		capability_process(&dev_info, &ciphers, &auths);
 
 		if (global->devs[n].disable_aes_cmac)
-			capability->auths.bit.aes_cmac = 0;
+			auths.bit.aes_cmac = 0;
+
+		capability->ciphers.all_bits |= ciphers.all_bits;
+		capability->auths.all_bits |= auths.all_bits;
 
 		if ((dev_info.feature_flags &
 		     RTE_CRYPTODEV_FF_HW_ACCELERATED)) {
-			capability->hw_ciphers = capability->ciphers;
-			capability->hw_auths = capability->auths;
+			capability->hw_ciphers.all_bits |= ciphers.all_bits;
+			capability->hw_auths.all_bits |= auths.all_bits;
 		}
 
 		/* Report the lowest max_nb_sessions of all devices */

--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -471,9 +471,14 @@ int _odp_crypto_init_global(void)
 			.socket_id = socket_id,
 		};
 
-		if (dev_info.driver_name && !strcmp(dev_info.driver_name, "crypto_openssl"))
+		if (dev_info.driver_name && !strcmp(dev_info.driver_name, "crypto_openssl")) {
 			global->devs[global->num_devs].disable_aes_cmac =
 				config.openssl_disable_aes_cmac;
+			if (odp_global_ro.init_param.mem_model == ODP_MEM_MODEL_PROCESS) {
+				_ODP_ERR("Disabling crypto_openssl: process mode not supported\n");
+				continue;
+			}
+		}
 
 		if (global->session_mempool[socket_id] == NULL) {
 			char mp_name[RTE_MEMPOOL_NAMESIZE];

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,8 +1,12 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation
 	thread_count_max = 8
+}
+
+crypto: {
+	max_num_sessions = 4000
 }

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation

--- a/platform/linux-dpdk/test/crypto.conf
+++ b/platform/linux-dpdk/test/crypto.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 system: {
 	# One crypto queue pair is required per thread for lockless operation

--- a/platform/linux-dpdk/test/default-timer.conf
+++ b/platform/linux-dpdk/test/default-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 timer: {
 	# Use DPDK default timer API based implementation

--- a/platform/linux-dpdk/test/default-timer.conf
+++ b/platform/linux-dpdk/test/default-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 timer: {
 	# Use DPDK default timer API based implementation

--- a/platform/linux-dpdk/test/default-timer.conf
+++ b/platform/linux-dpdk/test/default-timer.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 timer: {
 	# Use DPDK default timer API based implementation

--- a/platform/linux-dpdk/test/example/ipsec_api/pktio_env
+++ b/platform/linux-dpdk/test/example/ipsec_api/pktio_env
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (C) 2021 Marvell
+# Copyright (C) 2025 Nokia
 #
 # Script to setup interfaces used for running application on linux-dpdk.
 #
@@ -30,6 +31,11 @@ fi
 # Skip IPsec example tests when there's no OpenSSL.
 if [ -n "$WITH_OPENSSL" ] && [ ${WITH_OPENSSL} -eq 0 ]; then
 	echo "Crypto not supported. Skipping."
+	exit 77
+fi
+
+if [ -n "$ODPH_PROC_MODE" ] && [ ${ODPH_PROC_MODE} -ne 0 ]; then
+	echo "Process mode not supported. Skipping."
 	exit 77
 fi
 

--- a/platform/linux-dpdk/test/example/ipsec_crypto/pktio_env
+++ b/platform/linux-dpdk/test/example/ipsec_crypto/pktio_env
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (C) 2021 Marvell
+# Copyright (C) 2025 Nokia
 #
 # Script to setup interfaces used for running application on linux-dpdk.
 #
@@ -30,6 +31,11 @@ fi
 # Skip IPsec example tests when there's no OpenSSL.
 if [ -n "$WITH_OPENSSL" ] && [ ${WITH_OPENSSL} -eq 0 ]; then
 	echo "Crypto not supported. Skipping."
+	exit 77
+fi
+
+if [ -n "$ODPH_PROC_MODE" ] && [ ${ODPH_PROC_MODE} -ne 0 ]; then
+	echo "Process mode not supported. Skipping."
 	exit 77
 fi
 

--- a/platform/linux-dpdk/test/process-mode.conf
+++ b/platform/linux-dpdk/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 dpdk: {
 	process_mode_memory_mb = 1024

--- a/platform/linux-dpdk/test/process-mode.conf
+++ b/platform/linux-dpdk/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 dpdk: {
 	process_mode_memory_mb = 1024

--- a/platform/linux-dpdk/test/process-mode.conf
+++ b/platform/linux-dpdk/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 dpdk: {
 	process_mode_memory_mb = 1024

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-dpdk/test/sched-basic.conf
+++ b/platform/linux-dpdk/test/sched-basic.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # Test scheduler with an odd spread value and without dynamic load balance
 sched_basic: {

--- a/platform/linux-dpdk/test/stash-custom.conf
+++ b/platform/linux-dpdk/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.28"
+config_file_version = "0.1.29"
 
 # Test overflow safe stash variant
 stash: {

--- a/platform/linux-dpdk/test/stash-custom.conf
+++ b/platform/linux-dpdk/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.29"
+config_file_version = "0.1.30"
 
 # Test overflow safe stash variant
 stash: {

--- a/platform/linux-dpdk/test/stash-custom.conf
+++ b/platform/linux-dpdk/test/stash-custom.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-dpdk"
-config_file_version = "0.1.27"
+config_file_version = "0.1.28"
 
 # Test overflow safe stash variant
 stash: {

--- a/platform/linux-dpdk/test/validation/api/pktio/.gitignore
+++ b/platform/linux-dpdk/test/validation/api/pktio/.gitignore
@@ -1,1 +1,2 @@
-../../../../../linux-generic/test/validation/api/pktio/.gitignore
+*.log
+*.trs

--- a/platform/linux-dpdk/test/wrapper-script.sh
+++ b/platform/linux-dpdk/test/wrapper-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:-"--vdev=crypto_openssl --vdev=crypto_null"}
+export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:-"--vdev=crypto_null --vdev=crypto_openssl"}
 # where to mount huge pages
 export HUGEPAGEDIR=${HUGEPAGEDIR:-/mnt/huge}
 # exit codes expected by automake for skipped tests

--- a/platform/linux-dpdk/test/wrapper-script.sh
+++ b/platform/linux-dpdk/test/wrapper-script.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:-"--vdev=crypto_null --vdev=crypto_openssl"}
+dev1="--vdev=crypto_null,max_nb_queue_pairs=256"
+dev2="--vdev=crypto_openssl,max_nb_queue_pairs=256"
+export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:-"$dev1 $dev2"}
 # where to mount huge pages
 export HUGEPAGEDIR=${HUGEPAGEDIR:-/mnt/huge}
 # exit codes expected by automake for skipped tests


### PR DESCRIPTION
Miscellaneous improvements and fixes. These are needed for CI to work again with the newer DPDK version:

linux-dpdk: test: skip ipsec examples in process mode
linux-dpdk: crypto: add config option for disabling broken AES-CMAC
linux-dpdk: crypto: disable crypto_openssl driver in process mode
