### PR TITLE
[PATCH v2] github_ci: update coverity test image

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ env:
   CC: gcc
   ARCH: x86_64
   CONTAINER_NAMESPACE: ghcr.io/opendataplane/odp-docker-images
-  OS: ubuntu_20.04
+  OS: ubuntu_24.04
   COVERITY_EMAIL: dummy@opendataplane.org
   COVERITY_PROJECT: ODP-DPDK
 


### PR DESCRIPTION
Update Coverity test image to Ubuntu 24.04 variant, which includes DPDK v24.11. This fixes Coverity scan failures in the CI, caused by unsupported DPDK version (v22.11) in Ubuntu 20.04 image.