### PR TITLE
[PATCH v2] linux-dpdk: ml: fix operands don't affect result warning

### DIFF
--- a/platform/linux-dpdk/odp_ml.c
+++ b/platform/linux-dpdk/odp_ml.c
@@ -2103,7 +2103,7 @@ int _odp_ml_init_global(void)
 		goto error;
 	}
 
-	if (_ODP_ROUNDUP_POWER2_U32(info->align_size) != info->align_size) {
+	if (!_ODP_CHECK_IS_POWER2(info->align_size)) {
 		_ODP_ERR("ML device alignment size is not a power of two\n");
 		goto error;
 	}


### PR DESCRIPTION
Fix Coverity CONSTANT_EXPRESSION_RESULT warning if align_size > 2147483648U. This is not actually possible but the new check is cleaner anyway.